### PR TITLE
feat: Accordion 컴포넌트 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.0.5",
         "axios": "^1.5.1",
         "clsx": "^2.0.0",
+        "framer-motion": "^10.16.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.47.0",
@@ -11325,6 +11326,44 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.4.tgz",
+      "integrity": "sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -18002,8 +18041,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@suspensive/react": "^1.17.5",
     "@tanstack/react-query": "^5.0.5",
     "axios": "^1.5.1",
+    "framer-motion": "^10.16.4",
     "clsx": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/shared/Accordion/Accordion.stories.tsx
+++ b/src/shared/Accordion/Accordion.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Accordion, AccordionHeader, AccordionBody } from '.';
+import { Accordion, AccordionHeader, AccordionBody, AccordionGroup } from '.';
 
 const meta = {
   title: 'Shared/Accordion',
@@ -90,7 +90,7 @@ export const Custom: Story = {
       description: {
         story:
           '`AccordionHeader`, `AccordionBody` 에 className 을 부여하고, 하위 노드를 자유롭게 작성하여 커스텀할 수 있습니다.\
-           <br/><b>대부분의 커스텀 스타일은 아코디언 컴포넌트가 아닌, 하위의 children 상에서 부여하는 것을 권장합니다! (특히, 위아래 padding)</b>'
+           <br/><b>하지만 대부분의 커스텀 스타일은 아코디언 컴포넌트가 아닌, 하위의 children 상에서 부여하는 것을 권장합니다! (특히, 위아래 padding)</b>'
       }
     }
   },
@@ -117,6 +117,79 @@ export const Custom: Story = {
             </small>
           </AccordionBody>
         </Accordion>
+      </div>
+    );
+  }
+};
+
+export const Group: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'AccordionGroup 을 사용하여, AccordionHeader 와 AccordionBody 에 className 으로 부여되는 스타일을 일괄적용할 수 있습니다.'
+      }
+    }
+  },
+  render: () => {
+    return (
+      <div className="font-IMHyemin-bold">
+        <AccordionGroup
+          headerStyle="relative z-10 rounded-2xl border bg-light-main p-4 shadow-md"
+          bodyStyle="relative top-[-20px] z-0 rounded-2xl border shadow"
+        >
+          <Accordion>
+            <AccordionHeader buttonColored>
+              <div>Section 1</div>
+              <small>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+                dolorem qui similique quisquam vitae
+              </small>
+            </AccordionHeader>
+            <AccordionBody>
+              <small className="block p-3 pt-6">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Neque
+                quia doloremque, sit praesentium totam non possimus molestias
+                quod, mollitia ducimus provident. Corrupti soluta sit dolor
+                voluptas consequatur ex dolores veritatis.
+              </small>
+            </AccordionBody>
+          </Accordion>
+          <Accordion>
+            <AccordionHeader buttonColored>
+              <div>Section 1</div>
+              <small>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+                dolorem qui similique quisquam vitae
+              </small>
+            </AccordionHeader>
+            <AccordionBody>
+              <small className="block p-3 pt-6">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Neque
+                quia doloremque, sit praesentium totam non possimus molestias
+                quod, mollitia ducimus provident. Corrupti soluta sit dolor
+                voluptas consequatur ex dolores veritatis.
+              </small>
+            </AccordionBody>
+          </Accordion>
+          <Accordion>
+            <AccordionHeader buttonColored>
+              <div>Section 1</div>
+              <small>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+                dolorem qui similique quisquam vitae
+              </small>
+            </AccordionHeader>
+            <AccordionBody>
+              <small className="block p-3 pt-6">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Neque
+                quia doloremque, sit praesentium totam non possimus molestias
+                quod, mollitia ducimus provident. Corrupti soluta sit dolor
+                voluptas consequatur ex dolores veritatis.
+              </small>
+            </AccordionBody>
+          </Accordion>
+        </AccordionGroup>
       </div>
     );
   }

--- a/src/shared/Accordion/Accordion.stories.tsx
+++ b/src/shared/Accordion/Accordion.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Accordion, AccordionHeader, AccordionBody } from '.';
+
+const meta = {
+  title: 'Shared/Accordion',
+  tags: ['autodocs']
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '펼치기/접기로 기능하는 아코디언 컴포넌트입니다.'
+      }
+    }
+  },
+  render: () => {
+    return (
+      <div className="font-IMHyemin-bold">
+        <Accordion>
+          <AccordionHeader>
+            <div>Section 1</div>
+          </AccordionHeader>
+          <AccordionBody>
+            <small>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+              dolorem qui similique quisquam vitae Lorem ipsum dolor sit amet,
+              consectetur adipisicing elit. Neque quia doloremque, sit
+              praesentium totam non possimus molestias quod, mollitia ducimus
+              provident. Corrupti soluta sit dolor voluptas consequatur ex
+              dolores veritatis.
+            </small>
+          </AccordionBody>
+        </Accordion>
+      </div>
+    );
+  }
+};
+
+export const DarkMode: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '아코디언 오픈 시 버튼에게 포인트 색상을 주고 싶다면, 헤더에게 buttonColored 를 부여합니다.'
+      }
+    }
+  },
+  render: () => {
+    return (
+      <div className="dark font-IMHyemin-bold text-white">
+        <Accordion>
+          <AccordionHeader
+            className="bg-dark-main p-6"
+            buttonColored
+          >
+            <div className="flex items-center gap-4">
+              <div className="h-8 w-8 rounded-full bg-slate-400"></div>
+              <div>Section 1</div>
+            </div>
+            <small className="mt-5 block font-IMHyemin-regular">
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+              dolorem qui similique quisquam vitae Lorem ipsum dolor sit amet,
+              consectetur adipisicing elit.
+            </small>
+          </AccordionHeader>
+          <AccordionBody className="bg-dark-sub font-IMHyemin-regular">
+            <small className="block p-5">
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+              dolorem qui similique quisquam vitae Lorem ipsum dolor sit amet,
+              consectetur adipisicing elit. Neque quia doloremque, sit
+              praesentium totam non possimus molestias quod, mollitia ducimus
+              provident. Corrupti soluta sit dolor voluptas consequatur ex
+              dolores veritatis.
+            </small>
+          </AccordionBody>
+        </Accordion>
+      </div>
+    );
+  }
+};
+
+export const Custom: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`AccordionHeader`, `AccordionBody` 에 className 을 부여하고, 하위 노드를 자유롭게 작성하여 커스텀할 수 있습니다.\
+           <br/><b>대부분의 커스텀 스타일은 아코디언 컴포넌트가 아닌, 하위의 children 상에서 부여하는 것을 권장합니다! (특히, 위아래 padding)</b>'
+      }
+    }
+  },
+  render: () => {
+    return (
+      <div className="font-IMHyemin-bold">
+        <Accordion>
+          <AccordionHeader
+            className="relative z-10 rounded-2xl border bg-light-main p-4 shadow-md"
+            buttonColored
+          >
+            <div>Section 1</div>
+            <small>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
+              dolorem qui similique quisquam vitae
+            </small>
+          </AccordionHeader>
+          <AccordionBody className="relative top-[-20px] z-0 rounded-2xl border shadow">
+            <small className="block p-3 pt-6">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Neque
+              quia doloremque, sit praesentium totam non possimus molestias
+              quod, mollitia ducimus provident. Corrupti soluta sit dolor
+              voluptas consequatur ex dolores veritatis.
+            </small>
+          </AccordionBody>
+        </Accordion>
+      </div>
+    );
+  }
+};

--- a/src/shared/Accordion/Accordion.stories.tsx
+++ b/src/shared/Accordion/Accordion.stories.tsx
@@ -137,9 +137,10 @@ export const Group: Story = {
         <AccordionGroup
           headerStyle="relative z-10 rounded-2xl border bg-light-main p-4 shadow-md"
           bodyStyle="relative top-[-20px] z-0 rounded-2xl border shadow"
+          buttonColored
         >
           <Accordion>
-            <AccordionHeader buttonColored>
+            <AccordionHeader>
               <div>Section 1</div>
               <small>
                 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
@@ -156,7 +157,7 @@ export const Group: Story = {
             </AccordionBody>
           </Accordion>
           <Accordion>
-            <AccordionHeader buttonColored>
+            <AccordionHeader>
               <div>Section 1</div>
               <small>
                 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint
@@ -173,7 +174,7 @@ export const Group: Story = {
             </AccordionBody>
           </Accordion>
           <Accordion>
-            <AccordionHeader buttonColored>
+            <AccordionHeader>
               <div>Section 1</div>
               <small>
                 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sint

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -10,7 +10,7 @@ const Accordion = ({ children }: AccordionProps) => {
   const toggleOpen = () => setIsOpen((prev) => !prev);
 
   return (
-    <div className="w-full overflow-hidden">
+    <div className="overflow-hidden">
       <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
         {children}
       </AccordionContext.Provider>

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -10,7 +10,7 @@ const Accordion = ({ children }: AccordionProps) => {
   const toggleOpen = () => setIsOpen((prev) => !prev);
 
   return (
-    <div className="overflow-hidden">
+    <div className="overflow-hidden p-1">
       <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
         {children}
       </AccordionContext.Provider>

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { AccordionContext } from '../hooks/useAccordion';
+
+interface AccordionProps {
+  children: React.ReactNode;
+}
+
+const Accordion = ({ children }: AccordionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleOpen = () => setIsOpen((prev) => !prev);
+
+  return (
+    <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
+      {children}
+    </AccordionContext.Provider>
+  );
+};
+
+export default Accordion;

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -10,9 +10,11 @@ const Accordion = ({ children }: AccordionProps) => {
   const toggleOpen = () => setIsOpen((prev) => !prev);
 
   return (
-    <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
-      {children}
-    </AccordionContext.Provider>
+    <div className="w-full overflow-hidden">
+      <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
+        {children}
+      </AccordionContext.Provider>
+    </div>
   );
 };
 

--- a/src/shared/Accordion/components/AccordionBody.tsx
+++ b/src/shared/Accordion/components/AccordionBody.tsx
@@ -10,6 +10,7 @@ interface AccordionBodyProps {
 
 const AccordionBody = ({ children, className }: AccordionBodyProps) => {
   const { isOpen } = useAccordion();
+
   return (
     <AnimatePresence>
       {isOpen && (

--- a/src/shared/Accordion/components/AccordionBody.tsx
+++ b/src/shared/Accordion/components/AccordionBody.tsx
@@ -15,11 +15,11 @@ const AccordionBody = ({ children, className }: AccordionBodyProps) => {
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          initial={{ height: 0 }}
-          animate={{ height: 'auto' }}
-          exit={{ height: 0 }}
-          transition={{ type: 'spring', duration: 0.7, bounce: 0 }}
-          className={'overflow-hidden' + `${className ? className : ''}`}
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: 'auto', opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ type: 'spring', duration: 0.8, bounce: 0 }}
+          className={'box-border h-auto ' + `${className ? className : ''}`}
         >
           <div>{children}</div>
         </motion.div>

--- a/src/shared/Accordion/components/AccordionBody.tsx
+++ b/src/shared/Accordion/components/AccordionBody.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { clsx } from 'clsx';
+import { AnimatePresence, motion } from 'framer-motion';
 import useAccordion from '../hooks/useAccordion';
 
 interface AccordionBodyProps {
@@ -8,7 +10,21 @@ interface AccordionBodyProps {
 
 const AccordionBody = ({ children, className }: AccordionBodyProps) => {
   const { isOpen } = useAccordion();
-  return <div className={className ? className : ''}>{isOpen && children}</div>;
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ height: 0 }}
+          animate={{ height: 'auto' }}
+          exit={{ height: 0 }}
+          transition={{ type: 'spring', duration: 0.7, bounce: 0 }}
+          className={'overflow-hidden' + `${className ? className : ''}`}
+        >
+          <div>{children}</div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
 };
 
 export default AccordionBody;

--- a/src/shared/Accordion/components/AccordionBody.tsx
+++ b/src/shared/Accordion/components/AccordionBody.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { clsx } from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 import useAccordion from '../hooks/useAccordion';
+import useAccordionGroup from '../hooks/useAccordionGroup';
 
 interface AccordionBodyProps {
   children: React.ReactNode;
@@ -10,6 +10,7 @@ interface AccordionBodyProps {
 
 const AccordionBody = ({ children, className }: AccordionBodyProps) => {
   const { isOpen } = useAccordion();
+  const { bodyStyle } = useAccordionGroup();
 
   return (
     <AnimatePresence>
@@ -19,7 +20,11 @@ const AccordionBody = ({ children, className }: AccordionBodyProps) => {
           animate={{ height: 'auto', opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
           transition={{ type: 'spring', duration: 0.8, bounce: 0 }}
-          className={'box-border h-auto ' + `${className ? className : ''}`}
+          className={
+            'box-border h-auto ' +
+            `${bodyStyle} ` +
+            `${className ? className : ''}`
+          }
         >
           <div>{children}</div>
         </motion.div>

--- a/src/shared/Accordion/components/AccordionBody.tsx
+++ b/src/shared/Accordion/components/AccordionBody.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import useAccordion from '../hooks/useAccordion';
+
+interface AccordionBodyProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const AccordionBody = ({ children, className }: AccordionBodyProps) => {
+  const { isOpen } = useAccordion();
+  return <div className={className ? className : ''}>{isOpen && children}</div>;
+};
+
+export default AccordionBody;

--- a/src/shared/Accordion/components/AccordionGroup.tsx
+++ b/src/shared/Accordion/components/AccordionGroup.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { AccordionGroupContext } from '../hooks/useAccordionGroup';
+
+interface AccordionGroupProps {
+  headerStyle?: string;
+  bodyStyle?: string;
+  children: React.ReactNode;
+}
+
+const AccordionGroup = ({
+  headerStyle = '',
+  bodyStyle = '',
+  children
+}: AccordionGroupProps) => {
+  return (
+    <AccordionGroupContext.Provider value={{ headerStyle, bodyStyle }}>
+      {children}
+    </AccordionGroupContext.Provider>
+  );
+};
+
+export default AccordionGroup;

--- a/src/shared/Accordion/components/AccordionGroup.tsx
+++ b/src/shared/Accordion/components/AccordionGroup.tsx
@@ -4,16 +4,20 @@ import { AccordionGroupContext } from '../hooks/useAccordionGroup';
 interface AccordionGroupProps {
   headerStyle?: string;
   bodyStyle?: string;
+  buttonColored?: boolean;
   children: React.ReactNode;
 }
 
 const AccordionGroup = ({
   headerStyle = '',
   bodyStyle = '',
+  buttonColored = false,
   children
 }: AccordionGroupProps) => {
   return (
-    <AccordionGroupContext.Provider value={{ headerStyle, bodyStyle }}>
+    <AccordionGroupContext.Provider
+      value={{ headerStyle, bodyStyle, buttonColored }}
+    >
       {children}
     </AccordionGroupContext.Provider>
   );

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { clsx } from 'clsx';
+import { motion } from 'framer-motion';
 import useAccordion from '../hooks/useAccordion';
 import { Icon } from '@/shared/Icon';
 
@@ -8,14 +10,26 @@ export interface AccordionHeaderProps {
 }
 
 const AccordionHeader = ({ children, className }: AccordionHeaderProps) => {
-  const { toggleOpen } = useAccordion();
+  const { isOpen, toggleOpen } = useAccordion();
   return (
-    <div className={'flex' + `${className ? className : ''}`}>
+    <motion.div
+      className={
+        'flex justify-between items-center' + `${className ? className : ''}`
+      }
+    >
       <div>{children}</div>
-      <div onClick={toggleOpen}>
-        <Icon icon="BiChevronUpCircle" />
+      <div
+        onClick={toggleOpen}
+        className={clsx('cursor-pointer duration-300 ease-in', {
+          'rotate-180': isOpen
+        })}
+      >
+        <Icon
+          icon="BiChevronUpCircle"
+          size="2xl"
+        />
       </div>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { clsx } from 'clsx';
 import { motion } from 'framer-motion';
 import useAccordion from '../hooks/useAccordion';
+import useAccordionGroup from '../hooks/useAccordionGroup';
 import { Icon } from '@/shared/Icon';
 
 export interface AccordionHeaderProps {
@@ -16,11 +17,14 @@ const AccordionHeader = ({
   className
 }: AccordionHeaderProps) => {
   const { isOpen, toggleOpen } = useAccordion();
+  const { headerStyle } = useAccordionGroup();
 
   return (
     <motion.div
       className={
-        'flex justify-between items-center ' + `${className ? className : ''}`
+        'flex justify-between items-center ' +
+        `${headerStyle} ` +
+        `${className ? className : ''}`
       }
     >
       <div>{children}</div>

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -17,7 +17,8 @@ const AccordionHeader = ({
   className
 }: AccordionHeaderProps) => {
   const { isOpen, toggleOpen } = useAccordion();
-  const { headerStyle } = useAccordionGroup();
+  const { headerStyle, buttonColored: headerButtonColored } =
+    useAccordionGroup();
 
   return (
     <motion.div
@@ -32,8 +33,10 @@ const AccordionHeader = ({
         onClick={toggleOpen}
         className={clsx('ml-3 cursor-pointer duration-300 ease-in', {
           'rotate-180': isOpen,
-          'text-light-point dark:text-dark-point': buttonColored && isOpen,
-          'text-black dark:text-white': !buttonColored && isOpen,
+          'text-light-point dark:text-dark-point':
+            (buttonColored || headerButtonColored) && isOpen,
+          'text-black dark:text-white':
+            !(buttonColored || headerButtonColored) && isOpen,
           'text-dark-gray': !isOpen
         })}
       >

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -6,22 +6,31 @@ import { Icon } from '@/shared/Icon';
 
 export interface AccordionHeaderProps {
   children: React.ReactNode;
+  buttonColored?: boolean;
   className?: string;
 }
 
-const AccordionHeader = ({ children, className }: AccordionHeaderProps) => {
+const AccordionHeader = ({
+  children,
+  buttonColored = false,
+  className
+}: AccordionHeaderProps) => {
   const { isOpen, toggleOpen } = useAccordion();
+
   return (
     <motion.div
       className={
-        'flex justify-between items-center' + `${className ? className : ''}`
+        'flex justify-between items-center ' + `${className ? className : ''}`
       }
     >
       <div>{children}</div>
       <div
         onClick={toggleOpen}
         className={clsx('cursor-pointer duration-300 ease-in', {
-          'rotate-180': isOpen
+          'rotate-180': isOpen,
+          'text-light-point dark:text-dark-point': buttonColored && isOpen,
+          'text-black dark:text-white': !buttonColored && isOpen,
+          'text-dark-gray': !isOpen
         })}
       >
         <Icon

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -26,7 +26,7 @@ const AccordionHeader = ({
       <div>{children}</div>
       <div
         onClick={toggleOpen}
-        className={clsx('cursor-pointer duration-300 ease-in', {
+        className={clsx('ml-3 cursor-pointer duration-300 ease-in', {
           'rotate-180': isOpen,
           'text-light-point dark:text-dark-point': buttonColored && isOpen,
           'text-black dark:text-white': !buttonColored && isOpen,

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import useAccordion from '../hooks/useAccordion';
+import { Icon } from '@/shared/Icon';
+
+export interface AccordionHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const AccordionHeader = ({ children, className }: AccordionHeaderProps) => {
+  const { toggleOpen } = useAccordion();
+  return (
+    <div className={'flex' + `${className ? className : ''}`}>
+      <div>{children}</div>
+      <div onClick={toggleOpen}>
+        <Icon icon="BiChevronUpCircle" />
+      </div>
+    </div>
+  );
+};
+
+export default AccordionHeader;

--- a/src/shared/Accordion/hooks/useAccordion.ts
+++ b/src/shared/Accordion/hooks/useAccordion.ts
@@ -1,0 +1,12 @@
+import { useContext, createContext } from 'react';
+
+export const AccordionContext = createContext({
+  isOpen: false,
+  toggleOpen: () => {}
+});
+
+const useAccordion = () => {
+  return useContext(AccordionContext);
+};
+
+export default useAccordion;

--- a/src/shared/Accordion/hooks/useAccordionGroup.ts
+++ b/src/shared/Accordion/hooks/useAccordionGroup.ts
@@ -1,0 +1,12 @@
+import { useContext, createContext } from 'react';
+
+export const AccordionGroupContext = createContext({
+  headerStyle: '',
+  bodyStyle: ''
+});
+
+const useAccordionGroup = () => {
+  return useContext(AccordionGroupContext);
+};
+
+export default useAccordionGroup;

--- a/src/shared/Accordion/hooks/useAccordionGroup.ts
+++ b/src/shared/Accordion/hooks/useAccordionGroup.ts
@@ -2,7 +2,8 @@ import { useContext, createContext } from 'react';
 
 export const AccordionGroupContext = createContext({
   headerStyle: '',
-  bodyStyle: ''
+  bodyStyle: '',
+  buttonColored: false
 });
 
 const useAccordionGroup = () => {

--- a/src/shared/Accordion/index.ts
+++ b/src/shared/Accordion/index.ts
@@ -1,0 +1,3 @@
+export { default as Accordion } from './components/Accordion';
+export { default as AccordionHeader } from './components/AccordionHeader';
+export { default as AccordionBody } from './components/AccordionBody';

--- a/src/shared/Accordion/index.ts
+++ b/src/shared/Accordion/index.ts
@@ -1,3 +1,4 @@
 export { default as Accordion } from './components/Accordion';
 export { default as AccordionHeader } from './components/AccordionHeader';
 export { default as AccordionBody } from './components/AccordionBody';
+export { default as AccordionGroup } from './components/AccordionGroup';


### PR DESCRIPTION
## 🧩 이슈 번호
- close #51

## ✅ 작업 사항
아코디언 컴포넌트를 작성했습니다.
<img width="500" src="https://github.com/team-moabam/moabam-FE/assets/62418379/06e3f157-baf5-4138-b772-3f8f4a064d81"/>

컴포넌트 목록
- Accordion
- AccordionHeader
- AccordionBody
- AccordionGroup

## 👩‍💻 공유 포인트 및 논의 사항
### Accordion 사용법
> 아래와 같이 사용합니다.
```tsx
<Accordion>
  <AccordionHeader className="커스텀 스타일 클래스" buttonColored>

  {/* 헤더(접히지 않는 부분)에 들어가야 하는 내용 */}

  </AccordionHeader>
  <AccordionBody className="커스텀 스타일 클래스">
  
  {/* 바디(접히는 부분)에 들어가야 하는 내용 */}
  
  </AccordionBody>
</Accordion>
```

`AccordionHeader`
- buttonColored `optional` : 펼치기 버튼의 포인트컬러 유무를 결정합니다. 기본값은 false 입니다.
- className `optional` : AccordionHeader 에 className 을 부여하여 커스텀할 수 있습니다.

`AccordionBody`
- className `optional` : AccordionBody 에 className 을 부여하여 커스텀할 수 있습니다.

### AccordionGroup 사용법
커스텀이 많아지는 컴포넌트이기 때문에, 일괄 스타일 적용 (className, buttonColored) 이 가능하도록 했습니다.
적용 우선순위는 다음과 같습니다. (오른쪽으로 갈 수록 우선순위 높음)
`기본값 < AccordionGroup에 작성 < AccordionHeader,AccordionBody에 작성`

> 아래와 같이 사용합니다.
```tsx
<AccordionGroup 
  headerStyle="AccordionHeader에 일괄적용할 스타일 클래스" 
  bodyStyle="AccordionBody에 일괄적용할 스타일 클래스"
  buttonColored
>
  <Accordion>
    <AccordionHeader> Summary </AccordionHeader>
    <AccordionBody> Detail </AccordionBody>
  </Accordion>

  <Accordion>
    <AccordionHeader> Summary </AccordionHeader>
    <AccordionBody> Detail </AccordionBody>
  </Accordion>

  <Accordion>
    <AccordionHeader> Summary </AccordionHeader>
    <AccordionBody> Detail </AccordionBody>
  </Accordion>
</AccordionGroup>
```

### 주의 사항
> AccordionBody에 펼치고 닫는 애니메이션을 주기 위해 framer-motion 을 적용했는데, 위아래 패딩값에 따른 버그가 살짝 있습니다 ㅠ.
따라서 최대한 커스텀을 할 수 있도록 열어두긴 했지만, children 컴포넌트에서 처리가 가능한 스타일이라면 children 에게 부여하는 것을 권장합니다! 박스 위아래 패딩과 높이와 관련되지 않은 스타일은 얼마든지 바로 적용해도 무방합니다 :)