### PR TITLE
Fix: Accordion 컴포넌트 디폴트 너비 및 커스텀 범위 수정

### DIFF
--- a/src/shared/Accordion/Accordion.stories.tsx
+++ b/src/shared/Accordion/Accordion.stories.tsx
@@ -137,6 +137,7 @@ export const Group: Story = {
         <AccordionGroup
           headerStyle="relative z-10 rounded-2xl border bg-light-main p-4 shadow-md"
           bodyStyle="relative top-[-20px] z-0 rounded-2xl border shadow"
+          containerStyle="border"
           buttonColored
         >
           <Accordion>

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -2,15 +2,16 @@ import React, { useState } from 'react';
 import { AccordionContext } from '../hooks/useAccordion';
 
 interface AccordionProps {
+  className?: string;
   children: React.ReactNode;
 }
 
-const Accordion = ({ children }: AccordionProps) => {
+const Accordion = ({ children, className = '' }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleOpen = () => setIsOpen((prev) => !prev);
 
   return (
-    <div className="overflow-hidden p-1">
+    <div className={'w-full overflow-hidden p-1 ' + className}>
       <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
         {children}
       </AccordionContext.Provider>

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AccordionContext } from '../hooks/useAccordion';
+import useAccordionGroup from '../hooks/useAccordionGroup';
 
 interface AccordionProps {
   className?: string;
@@ -9,9 +10,14 @@ interface AccordionProps {
 const Accordion = ({ children, className = '' }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleOpen = () => setIsOpen((prev) => !prev);
+  const { containerStyle } = useAccordionGroup();
 
   return (
-    <div className={'w-full overflow-hidden p-1 ' + className}>
+    <div
+      className={
+        'w-full overflow-hidden p-1 ' + `${containerStyle} ` + className
+      }
+    >
       <AccordionContext.Provider value={{ isOpen, toggleOpen }}>
         {children}
       </AccordionContext.Provider>

--- a/src/shared/Accordion/components/AccordionBody.tsx
+++ b/src/shared/Accordion/components/AccordionBody.tsx
@@ -8,7 +8,7 @@ interface AccordionBodyProps {
   className?: string;
 }
 
-const AccordionBody = ({ children, className }: AccordionBodyProps) => {
+const AccordionBody = ({ children, className = '' }: AccordionBodyProps) => {
   const { isOpen } = useAccordion();
   const { bodyStyle } = useAccordionGroup();
 
@@ -20,11 +20,7 @@ const AccordionBody = ({ children, className }: AccordionBodyProps) => {
           animate={{ height: 'auto', opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
           transition={{ type: 'spring', duration: 0.8, bounce: 0 }}
-          className={
-            'box-border h-auto ' +
-            `${bodyStyle} ` +
-            `${className ? className : ''}`
-          }
+          className={'box-border h-auto ' + `${bodyStyle} ` + className}
         >
           <div>{children}</div>
         </motion.div>

--- a/src/shared/Accordion/components/AccordionGroup.tsx
+++ b/src/shared/Accordion/components/AccordionGroup.tsx
@@ -4,11 +4,13 @@ import { AccordionGroupContext } from '../hooks/useAccordionGroup';
 interface AccordionGroupProps {
   headerStyle?: string;
   bodyStyle?: string;
+  containerStyle?: string;
   buttonColored?: boolean;
   children: React.ReactNode;
 }
 
 const AccordionGroup = ({
+  containerStyle = '',
   headerStyle = '',
   bodyStyle = '',
   buttonColored = false,
@@ -16,7 +18,7 @@ const AccordionGroup = ({
 }: AccordionGroupProps) => {
   return (
     <AccordionGroupContext.Provider
-      value={{ headerStyle, bodyStyle, buttonColored }}
+      value={{ containerStyle, headerStyle, bodyStyle, buttonColored }}
     >
       {children}
     </AccordionGroupContext.Provider>

--- a/src/shared/Accordion/components/AccordionHeader.tsx
+++ b/src/shared/Accordion/components/AccordionHeader.tsx
@@ -14,7 +14,7 @@ export interface AccordionHeaderProps {
 const AccordionHeader = ({
   children,
   buttonColored = false,
-  className
+  className = ''
 }: AccordionHeaderProps) => {
   const { isOpen, toggleOpen } = useAccordion();
   const { headerStyle, buttonColored: headerButtonColored } =
@@ -23,9 +23,7 @@ const AccordionHeader = ({
   return (
     <motion.div
       className={
-        'flex justify-between items-center ' +
-        `${headerStyle} ` +
-        `${className ? className : ''}`
+        'flex justify-between items-center ' + `${headerStyle} ` + className
       }
     >
       <div>{children}</div>

--- a/src/shared/Accordion/hooks/useAccordionGroup.ts
+++ b/src/shared/Accordion/hooks/useAccordionGroup.ts
@@ -1,6 +1,7 @@
 import { useContext, createContext } from 'react';
 
 export const AccordionGroupContext = createContext({
+  containerStyle: '',
   headerStyle: '',
   bodyStyle: '',
   buttonColored: false


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호
- close #81 

## ✅ 작업 사항

1.  **Accordion w-full 추가하기** (default!)
2.  Accordion prop 추가하기
3.  Accordion group 에 containerStyle 추가하기 (커스텀 className 일괄 적용을 위한!)


## 👩‍💻 공유 포인트 및 논의 사항

### 사용방법
> Accordion 컴포넌트에게 바로 스타일을 넣어줄 수 있습니다.
```tsx
<Accordion className="여기에 추가하면 됩니다!">
  <AccordionHeader className="..."> </AccordionHeader>
  <AccordionBody className="..."> </AccordionBody>
</Accordion>
```


> AccordionGroup 의 **containerStyle** 을 통해 그룹 내 아코디언 스타일을 일괄 적용해줄 수 있습니다.

```tsx
  <AccordionGroup 
    headerStyle="relative z-10 rounded-2xl border bg-light-main p-4 shadow-md" 
    bodyStyle="relative top-[-20px] z-0 rounded-2xl border shadow" 
    containerStyle="border" 
    buttonColored>
    <Accordion>
      ...
    </Accordion>
    <Accordion>
      ...
    </Accordion>
 </AccordionGroup>   
```
