### PR TITLE
feat: prev prop 타입 RouteNames 로 수정

### DIFF
--- a/src/pages/RoomLog.tsx
+++ b/src/pages/RoomLog.tsx
@@ -7,7 +7,7 @@ const RoomLog = () => {
       <div className="dark:bg-dark-sub">
         <Header
           className="sticky  text-black"
-          prev="/"
+          prev="roomDetail"
           title="2023년 10월 8일"
         />
       </div>

--- a/src/pages/RoomNew.tsx
+++ b/src/pages/RoomNew.tsx
@@ -50,7 +50,7 @@ const RoomNew = () => {
       <FormProvider {...form}>
         <Header
           className="bg-light-main"
-          prev="#"
+          prev="routines"
           title="방 만들기"
         />
         <main className="grow overflow-auto px-8 py-12">

--- a/src/shared/Header/Header.stories.tsx
+++ b/src/shared/Header/Header.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {
   args: {
     title: '페이지 제목',
     titleSize: 'xl',
-    prev: '/'
+    prev: 'home'
   },
   parameters: {
     docs: {
@@ -46,7 +46,7 @@ export const OnlyPrev: Story = {
   render: () => {
     return (
       <div className="h-40 w-full border bg-light-main">
-        <Header prev="/" />
+        <Header prev="home" />
         <div className="m-10">page</div>
       </div>
     );
@@ -65,7 +65,7 @@ export const TitleSize: Story = {
     return (
       <div className="dark h-40 w-full border bg-dark-main">
         <Header
-          prev="/"
+          prev="home"
           title={
             <div className="flex items-center gap-3">
               2023년 10월 31일 <Icon icon="BiBugAlt" />

--- a/src/shared/Header/components/Header.tsx
+++ b/src/shared/Header/components/Header.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { RouteNames } from '@/core/routes';
+import { useMoveRoute } from '@/core/hooks';
 import { Icon } from '@/shared/Icon';
 
 interface HeaderProps {
-  prev?: string;
+  prev?: RouteNames;
   title?: React.ReactNode;
   titleSize?: 'md' | 'xl';
   children?: React.ReactNode;
@@ -19,6 +20,8 @@ const Header = ({
   children,
   className = ''
 }: HeaderProps) => {
+  const moveTo = useMoveRoute();
+
   return (
     <div
       className={twMerge(
@@ -27,15 +30,15 @@ const Header = ({
       )}
     >
       {prev && (
-        <Link
-          to={prev}
-          className="flex h-12 w-12 items-center justify-center"
+        <div
+          onClick={() => moveTo(prev)}
+          className="flex h-12 w-12 cursor-pointer items-center justify-center"
         >
           <Icon
             icon="BiChevronLeft"
             size="5xl"
           />
-        </Link>
+        </div>
       )}
       {title && (
         <div


### PR DESCRIPTION
## 🧩 이슈 번호 
- close #106

## ✅ 작업 사항
route 관련 기능을 보완했기 때문에, 이를 적용해서 **RouteName 타입**을 받도록 수정했습니다.
(useMoveRoute 훅 내에서 브라우저url 에 들어가 있는 파라미터값을 추적하기 때문에 파라미터값을 따로 작성하지 않아도 됩니다)

```ts
export type RouteNames =
  | 'home'
  | 'guide'
  | 'join'
  | 'routines'
  | 'search'
  | 'user'
  | 'myPage'
  | 'myLog'
  | 'createRoom'
  | 'room'
  | 'roomDetail'
  | 'roomLog'
  | 'roomSetting'
  | 'mybird'
  | 'notFound';
```

## 👩‍💻 공유 포인트 및 논의 사항

### 헤더 뒤로가기를 사용하는 페이지들
> 혹시 몰라서 정리했습니다!
Navbar 가 없기 때문에, prev 는 곧 NavBar 가 있는 페이지로의 탈출구여야 합니다!

* 루틴 인증 목록 페이지
    - prev = 'roomDetail'
* 새 커스텀 페이지
    - prev = 'myPage'
* 방 생성 페이지
    - prev = 'routines'
* 방 관리 페이지
    - prev = 'roomDetail'
 * 구매 내역, 쿠폰함, 랭킹, 방 참여 기록, 상점
    - prev = 'myPage'


https://github.com/team-moabam/moabam-FE/assets/62418379/e509cd16-dcfa-49af-8635-4874e49dff71


