### PR TITLE
fix: 탭바 오류 수정

### DIFF
--- a/src/shared/Tab/components/TabBar.tsx
+++ b/src/shared/Tab/components/TabBar.tsx
@@ -5,8 +5,7 @@ interface TabBarProps {
 
 const TabBar = ({ width, left }: TabBarProps) => {
   return (
-    width &&
-    left && (
+    width && (
       <div
         className="absolute h-1 rounded-sm bg-black transition-all duration-200 dark:bg-white"
         style={{ width, left, bottom: 0 }}


### PR DESCRIPTION
## 🧩 이슈 번호
- close #110

## ✅ 작업 사항
탭 컴포넌트에서 align-start 적용할 시, 탭바가 아니라 숫자 0 이 렌더링되는 버그를 수정했습니다.
