### PR TITLE
feat: 방 관리, 방 생성 페이지 TODO 코드 구현

### DIFF
--- a/src/RoomNew/components/Navbar.tsx
+++ b/src/RoomNew/components/Navbar.tsx
@@ -21,7 +21,7 @@ const Navbar = ({
 
   // 다음 스텝으로 넘어가기 전 각 스텝에서 수행되어야 할 유효성 검사 필드를 정의합니다.
   const validationMaps: Record<(typeof steps)[number], Array<keyof Inputs>> = {
-    BirdStep: ['type'],
+    BirdStep: ['roomType'],
     TimeStep: ['certifyTime'],
     RoutineStep: ['routines', 'title', 'userCount'],
     PasswordStep: ['password'],

--- a/src/RoomNew/hooks/useRoomForm.ts
+++ b/src/RoomNew/hooks/useRoomForm.ts
@@ -113,10 +113,6 @@ const useRoomForm = () => {
             setError('certifyTime', { message: certifyTime });
             setError('userCount', { message: maxUserCount });
           }
-
-          if (error.response?.status === 401) {
-            moveTo('join');
-          }
         }
       }
     );

--- a/src/RoomNew/hooks/useRoomForm.ts
+++ b/src/RoomNew/hooks/useRoomForm.ts
@@ -16,7 +16,7 @@ import {
 import { Toast } from '@/shared/Toast';
 
 export const formSchema = z.object({
-  type: z.enum(ROOM_TYPES),
+  roomType: z.enum(ROOM_TYPES),
   certifyTime: z.number(),
   routines: z.array(
     z.object({
@@ -58,7 +58,7 @@ const useRoomForm = () => {
 
   const form = useForm<Inputs>({
     defaultValues: {
-      type: 'MORNING',
+      roomType: 'MORNING',
       certifyTime: TIME_RANGE['MORNING'][0],
       routines: [{ value: '' }],
       userCount: 5,
@@ -74,8 +74,8 @@ const useRoomForm = () => {
       {
         title: data.title,
         password: data.password,
-        type: data.type,
-        routine: data.routines.map((r) => r.value),
+        roomType: data.roomType,
+        routines: data.routines.map((r) => r.value),
         certifyTime: data.certifyTime % 24,
         maxUserCount: data.userCount
       },
@@ -100,16 +100,16 @@ const useRoomForm = () => {
             const {
               title,
               password,
-              type,
-              routine,
+              roomType,
+              routines,
               certifyTime,
               maxUserCount
             } = error.response.data.validation;
 
             setError('title', { message: title });
             setError('password', { message: password });
-            setError('type', { message: type });
-            setError('routines', { message: routine });
+            setError('roomType', { message: roomType });
+            setError('routines', { message: routines });
             setError('certifyTime', { message: certifyTime });
             setError('userCount', { message: maxUserCount });
           }

--- a/src/RoomNew/hooks/useRoomForm.ts
+++ b/src/RoomNew/hooks/useRoomForm.ts
@@ -3,6 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import z from 'zod';
 import roomAPI from '@/core/api/functions/roomAPI';
+import { useMoveRoute } from '@/core/hooks';
 import {
   FORM_MESSAGE,
   ROOM_TYPES,
@@ -12,6 +13,7 @@ import {
   USER_COUNT,
   PASSWORD
 } from '@/RoomForm/constants/literals';
+import { Toast } from '@/shared/Toast';
 
 export const formSchema = z.object({
   type: z.enum(ROOM_TYPES),
@@ -48,6 +50,8 @@ export const formSchema = z.object({
 export type Inputs = z.infer<typeof formSchema>;
 
 const useRoomForm = () => {
+  const moveTo = useMoveRoute();
+
   const mutation = useMutation({
     mutationFn: roomAPI.postRoom
   });
@@ -77,15 +81,18 @@ const useRoomForm = () => {
       },
       {
         onSuccess: (data) => {
-          // TODO: toast({ message: '방이 생성되었습니다.', type: 'success' });
-          console.log(data.message);
+          Toast.show({
+            message: '새로운 방을 만들었어요.',
+            status: 'confirm'
+          });
 
-          // TODO: 방 상세 페이지로 redirect 해야 해요.
-          console.log('TODO: 방 상세 페이지로 redirect');
+          moveTo('roomDetail', { roomId: data.roomId });
         },
         onError: (error) => {
-          // TODO: toast({ message: '서버에서 날아온 에러 메시지.', type: 'error' });
-          console.log(error.response?.data?.message);
+          Toast.show({
+            message: error.response?.data?.message ?? '오류가 발생했어요.',
+            status: 'danger'
+          });
 
           if (error.response?.data?.validation) {
             const { setError } = form;
@@ -108,8 +115,7 @@ const useRoomForm = () => {
           }
 
           if (error.response?.status === 401) {
-            // TODO: 로그인 페이지로 redirect 해야 해요.
-            console.log('TODO: 로그인 페이지로 redirect');
+            moveTo('join');
           }
         }
       }

--- a/src/RoomNew/steps/BirdStep.tsx
+++ b/src/RoomNew/steps/BirdStep.tsx
@@ -15,7 +15,7 @@ const BirdStep = () => {
     formState: { errors }
   } = useFormContext<Inputs>();
 
-  const watchType = watch('type');
+  const watchType = watch('roomType');
 
   return (
     <>
@@ -29,20 +29,22 @@ const BirdStep = () => {
       </p>
 
       <section className="flex justify-around gap-10 pt-10 max-[320px]:flex-col">
-        {ROOM_TYPES.map((type) => (
+        {ROOM_TYPES.map((roomType) => (
           <BirdCard
-            key={type}
-            type={type}
-            active={watchType === type}
+            key={roomType}
+            type={roomType}
+            active={watchType === roomType}
             onClick={() => {
-              setValue('type', type);
-              setValue('certifyTime', TIME_RANGE[type][0]);
+              setValue('roomType', roomType);
+              setValue('certifyTime', TIME_RANGE[roomType][0]);
             }}
           />
         ))}
       </section>
 
-      {errors.type && <p className={errorStyle}>{errors.type.message}</p>}
+      {errors.roomType && (
+        <p className={errorStyle}>{errors.roomType.message}</p>
+      )}
     </>
   );
 };

--- a/src/RoomNew/steps/SummaryStep.tsx
+++ b/src/RoomNew/steps/SummaryStep.tsx
@@ -20,7 +20,7 @@ const SummaryStep = () => {
   const infos: Info[] = [
     {
       icon: 'PiBirdFill',
-      text: BIRD[getValues('type')].name
+      text: BIRD[getValues('roomType')].name
     },
     {
       icon: 'RiTimerLine',

--- a/src/RoomNew/steps/TimeStep.tsx
+++ b/src/RoomNew/steps/TimeStep.tsx
@@ -16,7 +16,7 @@ const TimeStep = () => {
     formState: { errors }
   } = useFormContext<Inputs>();
 
-  const watchType = watch('type');
+  const watchRoomType = watch('roomType');
   const watchCertifyTime = watch('certifyTime');
 
   return (
@@ -31,13 +31,13 @@ const TimeStep = () => {
       </p>
 
       <section className="mt-10 flex w-full flex-col items-center gap-6">
-        <div>{formatHourString(TIME_RANGE[watchType][0])}</div>
+        <div>{formatHourString(TIME_RANGE[watchRoomType][0])}</div>
         <TimePicker
-          range={TIME_RANGE[watchType]}
+          range={TIME_RANGE[watchRoomType]}
           initialTime={watchCertifyTime}
           onChangeTime={(time) => setValue('certifyTime', time)}
         />
-        <div>{formatHourString(TIME_RANGE[watchType][1])}</div>
+        <div>{formatHourString(TIME_RANGE[watchRoomType][1])}</div>
       </section>
 
       {errors.certifyTime && (

--- a/src/RoomSetting/hooks/useRoomForm.ts
+++ b/src/RoomSetting/hooks/useRoomForm.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import roomAPI from '@/core/api/functions/roomAPI';
+import { useMoveRoute } from '@/core/hooks';
 import {
   ANNOUNCEMENT,
   ROUTINE_NAME,
@@ -11,6 +12,7 @@ import {
   PASSWORD,
   FORM_MESSAGE
 } from '@/RoomForm/constants/literals';
+import { Toast } from '@/shared/Toast';
 
 export const formSchema = z.object({
   title: z
@@ -56,6 +58,8 @@ interface useRoomFormProps {
 }
 
 const useRoomForm = ({ roomId, defaultValues }: useRoomFormProps) => {
+  const moveTo = useMoveRoute();
+
   const mutation = useMutation({
     mutationFn: roomAPI.putRoom
   });
@@ -78,12 +82,19 @@ const useRoomForm = ({ roomId, defaultValues }: useRoomFormProps) => {
         password: data.password
       },
       {
-        onSuccess: (data) => console.log(data),
+        onSuccess: (data) => {
+          Toast.show({
+            message: '방 정보를 수정했어요.',
+            status: 'confirm'
+          });
+        },
         onError: (error) => {
           const { setError } = form;
 
-          // TODO: 에러 Toast 메시지를 보여줘야 해요.
-          console.log(error.response?.data?.message);
+          Toast.show({
+            message: error.response?.data?.message || '오류가 발생했어요.',
+            status: 'danger'
+          });
 
           if (error.response?.data?.validation) {
             const {
@@ -104,9 +115,7 @@ const useRoomForm = ({ roomId, defaultValues }: useRoomFormProps) => {
           }
 
           if (error.response?.status === 401) {
-            // TODO: 로그인 페이지로 redirect 해야 해요.
-            // TODO: 혹은 전역 MutationCache에 리다이렉션 관련 로직을 작업해야 해요.
-            console.log('TODO: 로그인 페이지로 redirect');
+            moveTo('join');
           }
         }
       }

--- a/src/RoomSetting/hooks/useRoomForm.ts
+++ b/src/RoomSetting/hooks/useRoomForm.ts
@@ -3,7 +3,6 @@ import z from 'zod';
 import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import roomAPI from '@/core/api/functions/roomAPI';
-import { useMoveRoute } from '@/core/hooks';
 import {
   ANNOUNCEMENT,
   ROUTINE_NAME,
@@ -58,8 +57,6 @@ interface useRoomFormProps {
 }
 
 const useRoomForm = ({ roomId, defaultValues }: useRoomFormProps) => {
-  const moveTo = useMoveRoute();
-
   const mutation = useMutation({
     mutationFn: roomAPI.putRoom
   });
@@ -112,10 +109,6 @@ const useRoomForm = ({ roomId, defaultValues }: useRoomFormProps) => {
             setError('password', { message: password });
             setError('certifyTime', { message: certifyTime });
             setError('userCount', { message: maxUserCount });
-          }
-
-          if (error.response?.status === 401) {
-            moveTo('join');
           }
         }
       }

--- a/src/RoomSetting/hooks/useRoomForm.ts
+++ b/src/RoomSetting/hooks/useRoomForm.ts
@@ -77,7 +77,7 @@ const useRoomForm = ({ roomId, defaultValues }: useRoomFormProps) => {
         title: data.title,
         announcement: data.announcement,
         certifyTime: data.certifyTime % 24,
-        routine: data.routines.map((r) => r.value),
+        routines: data.routines.map((r) => r.value),
         maxUserCount: data.userCount,
         password: data.password
       },

--- a/src/RoomSetting/tabs/MemberTab/DelegationButton.tsx
+++ b/src/RoomSetting/tabs/MemberTab/DelegationButton.tsx
@@ -4,6 +4,7 @@ import { useMoveRoute } from '@/core/hooks';
 import { ModalHeadingStyle, descriptionStyle, errorStyle } from './styles';
 import { BottomSheet, useBottomSheet } from '@/shared/BottomSheet';
 import { LoadingSpinner } from '@/shared/LoadingSpinner';
+import { Toast } from '@/shared/Toast';
 
 interface DelegationButtonProps {
   roomId: string;
@@ -30,9 +31,15 @@ const DelegationButton = ({
       {
         onSuccess: () => {
           moveTo('roomDetail');
-          // TODO: 토스트 메시지로 방장을 위임했음을 알려야 해요.
+          Toast.show({ message: '방장을 위임했어요.', status: 'confirm' });
         },
-        onError: (err) => console.error(err)
+        onError: (err) => {
+          console.error(err);
+          Toast.show({
+            message: err.response?.data.message ?? '오류가 발생했어요.',
+            status: 'danger'
+          });
+        }
       }
     );
   };

--- a/src/RoomSetting/tabs/MemberTab/KickButton.tsx
+++ b/src/RoomSetting/tabs/MemberTab/KickButton.tsx
@@ -5,6 +5,7 @@ import { ModalHeadingStyle, descriptionStyle } from './styles';
 import { Input } from '@/shared/Input';
 import { BottomSheet, useBottomSheet } from '@/shared/BottomSheet';
 import { LoadingSpinner } from '@/shared/LoadingSpinner';
+import { Toast } from '@/shared/Toast';
 
 interface KickButtonProps {
   roomId: string;
@@ -27,9 +28,18 @@ const KickButton = ({ roomId, memberId, nickname }: KickButtonProps) => {
       {
         onSuccess: () => {
           close();
-          // TODO: 토스트 메시지로 사용자를 추방했음을 알려야 해요.
+          Toast.show({
+            message: '멤버를 방에서 쫓아냈어요.',
+            status: 'danger'
+          });
         },
-        onError: (err) => console.error(err)
+        onError: (err) => {
+          console.error(err);
+          Toast.show({
+            message: err.response?.data.message ?? '오류가 발생했어요.',
+            status: 'danger'
+          });
+        }
       }
     );
   };

--- a/src/RoomSetting/tabs/MemberTab/index.tsx
+++ b/src/RoomSetting/tabs/MemberTab/index.tsx
@@ -16,7 +16,7 @@ const MemberTab = ({ roomId }: MemberTabProps) => {
 
   return (
     <div className="flex flex-col gap-4">
-      {room.todayCertificateRank.map((member) => (
+      {room.participants.map((member) => (
         <div
           className="flex items-center justify-between"
           key={member.memberId}
@@ -24,16 +24,18 @@ const MemberTab = ({ roomId }: MemberTabProps) => {
           <Avatar
             imgUrl={member.profileImage}
             nickname={member.nickname}
-            userId={member.memberId}
+            userId={member.memberId.toString()}
             contribution={member.contributionPoint}
           />
           <div className="flex gap-2">
             <KickButton
               {...member}
+              memberId={member.memberId.toString()}
               roomId={roomId}
             />
             <DelegationButton
               {...member}
+              memberId={member.memberId.toString()}
               roomId={roomId}
             />
           </div>

--- a/src/RoomSetting/tabs/RemoveTab.tsx
+++ b/src/RoomSetting/tabs/RemoveTab.tsx
@@ -5,6 +5,7 @@ import roomAPI from '@/core/api/functions/roomAPI';
 import { useMoveRoute } from '@/core/hooks';
 import { Input } from '@/shared/Input';
 import { LoadingSpinner } from '@/shared/LoadingSpinner';
+import { Toast } from '@/shared/Toast';
 
 interface RemoveTabProps {
   roomId: string;
@@ -27,9 +28,15 @@ const RemoveTab = ({ roomId }: RemoveTabProps) => {
     mutate(roomId, {
       onSuccess: () => {
         moveTo('routines');
-        // TODO: 토스트 메시지로 방을 삭제했음을 알려야 해요.
+        Toast.show({ message: '방을 삭제했어요.', status: 'confirm' });
       },
-      onError: (err) => console.error(err)
+      onError: (err) => {
+        console.error(err);
+        Toast.show({
+          message: err.response?.data.message ?? '오류가 발생했어요.',
+          status: 'danger'
+        });
+      }
     });
   };
 

--- a/src/RoomSetting/tabs/RemoveTab.tsx
+++ b/src/RoomSetting/tabs/RemoveTab.tsx
@@ -40,7 +40,7 @@ const RemoveTab = ({ roomId }: RemoveTabProps) => {
     });
   };
 
-  if (room.currentUserCount > 1) {
+  if (room.participants.length > 1) {
     return (
       <>
         <h1 className={headingStyle}>

--- a/src/RoomSetting/tabs/RoomTab.tsx
+++ b/src/RoomSetting/tabs/RoomTab.tsx
@@ -31,7 +31,7 @@ const RoomTab = ({ roomId }: RoomTabProps) => {
       title: room.title,
       announcement: room.announcement,
       certifyTime: room.certifyTime,
-      routines: room.routine.map((r) => ({ value: r.content })),
+      routines: room.routines.map((r) => ({ value: r.content })),
       userCount: room.maxUserCount,
       password: ''
     }

--- a/src/core/api/functions/roomAPI.ts
+++ b/src/core/api/functions/roomAPI.ts
@@ -7,8 +7,8 @@ const roomAPI = {
   postRoom: async (body: {
     title: string;
     password: string;
-    type: string;
-    routine: string[];
+    roomType: string;
+    routines: string[];
     certifyTime: number;
     maxUserCount: number;
   }) => {

--- a/src/core/api/functions/roomAPI.ts
+++ b/src/core/api/functions/roomAPI.ts
@@ -23,7 +23,7 @@ const roomAPI = {
     roomId: string;
     title: string;
     announcement: string;
-    routine: string[];
+    routines: string[];
     password: string;
     certifyTime: number;
     maxUserCount: number;

--- a/src/core/api/functions/roomAPI.ts
+++ b/src/core/api/functions/roomAPI.ts
@@ -1,7 +1,7 @@
 import { RoomsRequestParams, TotalRooms } from '@/core/types';
 import { baseInstance } from '../instance';
 import { MyJoinRoom } from '@/core/types/MyJoinRoom';
-import { RoomInfo } from '@/core/types/Room';
+import { RoomInfo, RoomInfoBeforeEditing } from '@/core/types/Room';
 
 const roomAPI = {
   postRoom: async (body: {
@@ -16,7 +16,7 @@ const roomAPI = {
   },
 
   getRoomDetail: async (roomId: string) => {
-    return await baseInstance.get<RoomInfo>(`/rooms/${roomId}`);
+    return await baseInstance.get<RoomInfoBeforeEditing>(`/rooms/${roomId}`);
   },
 
   putRoom: async (params: {

--- a/src/core/api/functions/roomAPI.ts
+++ b/src/core/api/functions/roomAPI.ts
@@ -19,6 +19,10 @@ const roomAPI = {
     return await baseInstance.get<RoomInfoBeforeEditing>(`/rooms/${roomId}`);
   },
 
+  getRoomDetailByDate: async (roomId: string, date: string) => {
+    return await baseInstance.get<RoomInfo>(`/rooms/${roomId}/${date}`);
+  },
+
   putRoom: async (params: {
     roomId: string;
     title: string;

--- a/src/core/api/functions/roomAPI.ts
+++ b/src/core/api/functions/roomAPI.ts
@@ -12,7 +12,7 @@ const roomAPI = {
     certifyTime: number;
     maxUserCount: number;
   }) => {
-    return await baseInstance.post<{ message: string }>('/rooms', body);
+    return await baseInstance.post<{ roomId: number }>('/rooms', body);
   },
 
   getRoomDetail: async (roomId: string) => {

--- a/src/core/api/options/room.ts
+++ b/src/core/api/options/room.ts
@@ -9,6 +9,12 @@ const roomOptions = {
       queryFn: () => roomAPI.getRoomDetail(roomId)
     }),
 
+  detailByDate: (roomId: string, date: string) =>
+    queryOptions({
+      queryKey: ['rooms', 'detail', roomId, date] as const,
+      queryFn: () => roomAPI.getRoomDetailByDate(roomId, date)
+    }),
+
   myJoin: () =>
     queryOptions({
       queryKey: ['rooms', 'myJoin'] as const,

--- a/src/core/mocks/datas/room.ts
+++ b/src/core/mocks/datas/room.ts
@@ -109,3 +109,37 @@ export const RoomInfo = {
     }
   ]
 };
+
+export const RoomInfoBeforeEditing = {
+  roomId: 3,
+  title: '재맹이의 방',
+  announcement: '방의 공지사항입니다!',
+  roomType: 'MORNING',
+  certifyTime: 9,
+  maxUserCount: 10,
+  password: '1234',
+  routines: [
+    {
+      routineId: 5,
+      content: '물 마시기'
+    },
+    {
+      routineId: 9,
+      content: '아침 먹기'
+    }
+  ],
+  participants: [
+    {
+      memberId: 4,
+      nickname: '참여자1',
+      contributionPoint: 70,
+      profileImage: 'https://~'
+    },
+    {
+      memberId: 8,
+      nickname: '참여자2',
+      contributionPoint: 70,
+      profileImage: 'https://~'
+    }
+  ]
+};

--- a/src/core/mocks/handlers/rooms.ts
+++ b/src/core/mocks/handlers/rooms.ts
@@ -13,7 +13,7 @@ const roomsHandlers = [
 
     switch (status) {
       case 201:
-        response = { message: '모킹 룸 생성 완료', roomId: 1 };
+        response = { roomId: 1 };
         break;
       case 400:
         response = {

--- a/src/core/mocks/handlers/rooms.ts
+++ b/src/core/mocks/handlers/rooms.ts
@@ -62,6 +62,27 @@ const roomsHandlers = [
     return HttpResponse.json(response, { status });
   }),
 
+  http.get(baseURL('/rooms/:roomId/:date'), async () => {
+    await delay(1000);
+
+    const status: number = 200;
+    let response = {};
+
+    switch (status) {
+      case 200:
+        response = RoomInfo;
+        break;
+      case 401:
+        response = { message: '존재하지 않는 유저입니다.' };
+        break;
+      case 404:
+        response = { message: '존재하지 않는 방입니다.' };
+        break;
+    }
+
+    return HttpResponse.json(response, { status });
+  }),
+
   http.put(baseURL('/rooms/:roomId'), async () => {
     await delay(1000);
 

--- a/src/core/mocks/handlers/rooms.ts
+++ b/src/core/mocks/handlers/rooms.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse, delay } from 'msw';
 import { baseURL } from '../baseURL';
-import { RoomInfo } from '../datas/room';
+import { RoomInfo, RoomInfoBeforeEditing } from '../datas/room';
 import { MY_JOIN_ROOMS } from '../datas/myJoinRoom';
 import { TOTAL_ROOMS } from '../datas/totalRooms';
 
@@ -49,7 +49,7 @@ const roomsHandlers = [
 
     switch (status) {
       case 200:
-        response = RoomInfo;
+        response = RoomInfoBeforeEditing;
         break;
       case 401:
         response = { message: '존재하지 않는 유저입니다.' };

--- a/src/core/mocks/handlers/rooms.ts
+++ b/src/core/mocks/handlers/rooms.ts
@@ -21,8 +21,8 @@ const roomsHandlers = [
           validation: {
             title: 'Title Error',
             password: 'Password Error',
-            type: 'Type Error',
-            routine: 'Routine Error',
+            roomType: 'RoomType Error',
+            routines: 'Routines Error',
             certifyTime: 'CertifyTime Error',
             maxUserCount: 'MaxUserCount Error'
           }

--- a/src/core/types/Room.ts
+++ b/src/core/types/Room.ts
@@ -17,3 +17,20 @@ export type RoomInfo = {
   routine: { routineId: number; content: string }[];
   todayCertificateRank: RankMember[];
 };
+
+export type RoomInfoBeforeEditing = {
+  roomId: number;
+  title: string;
+  announcement: string;
+  roomType: DayType;
+  certifyTime: number;
+  maxUserCount: number;
+  password: string;
+  routines: { routineId: number; content: string }[];
+  participants: {
+    memberId: number;
+    nickname: string;
+    contributionPoint: number;
+    profileImage: string;
+  }[];
+};

--- a/src/pages/RoomDetailPage.tsx
+++ b/src/pages/RoomDetailPage.tsx
@@ -7,9 +7,12 @@ import { Icon } from '@/shared/Icon';
 
 const RoomDetailPage = () => {
   const roomId = '1234';
+  const serverTime = new Date();
+
+  const todayDate = `${serverTime.getFullYear()}-${serverTime.getMonth()}-${serverTime.getDate()}`;
 
   const { data: roomDetailData, status } = useQuery({
-    ...roomOptions.detail(roomId)
+    ...roomOptions.detailByDate(roomId, todayDate)
   });
 
   if (status !== 'success') return <div>임시 Loading...</div>;

--- a/src/shared/Toast/components/ToastManager.tsx
+++ b/src/shared/Toast/components/ToastManager.tsx
@@ -50,7 +50,7 @@ const ToastManager = ({ bind }: ToastManagerProps) => {
   }, [bind, createToast]);
 
   return (
-    <div className="absolute bottom-[3.25rem] left-[50%] flex min-h-[2.75rem] w-full translate-x-[-50%] flex-col items-center">
+    <div className="absolute bottom-[3.25rem] left-[50%] flex min-h-[2.75rem] w-full translate-x-[-50%] flex-col items-center empty:hidden">
       {toasts.map(({ id, status, message, subText, icon, duration }) => (
         <ToastItem
           status={status}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #168 

## ✅ 작업 사항
- 토스트, 페이지 이동 등 방 관리, 방 생성 페이지 TODO 코드 구현
- API 변동 사항 반영

## 👩‍💻 공유 포인트 및 논의 사항
### ToastManager 컴포넌트

![image](https://github.com/team-moabam/moabam-FE/assets/50488780/e13fe0ee-fad9-4b3c-9035-3453d29cd3f6)

ToastManager 컴포넌트가 화면의 버튼을 가려서 클릭이 불가능한 현상을 발견했어요..  
우선 `empty:hidden` 클래스를 추가했는데, 이렇게 해도 문제가 없을까요??

### status 속성

현재 `status` 값으로 들어갈 수 있는게 `'confirm' | 'danger'` 인 것으로 확인했는데, 사용하다가 오타로 잘못된 값을 넣은 적이 있어서 다시 확인해야 하는 경우가 있었어요.

현재는 `string` 타입으로 받고 있어서 `'confirm' | 'danger'` 같이 더욱 좁힌 타입으로 받는 건 어떨까요!?  

![image](https://github.com/team-moabam/moabam-FE/assets/50488780/e0e8348c-32ba-4e6f-8462-de4484ed4019)
