### PR TITLE
fix: 루틴페이지 bug api 호출 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import 'swiper/css/bundle';
 const App = () => {
   const { navBarRequired, path } = useRouteData();
   const { theme, setTheme } = useTheme();
-  // useCheckAuthRequired();
+  useCheckAuthRequired();
 
   const { data, isSuccess } = useQuery({
     ...timeOption,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import 'swiper/css/bundle';
 const App = () => {
   const { navBarRequired, path } = useRouteData();
   const { theme, setTheme } = useTheme();
-  useCheckAuthRequired();
+  // useCheckAuthRequired();
 
   const { data, isSuccess } = useQuery({
     ...timeOption,

--- a/src/RoomSlide/components/RoomData.tsx
+++ b/src/RoomSlide/components/RoomData.tsx
@@ -1,11 +1,6 @@
-import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
-import { roomOptions, bugOptions } from '@/core/api/options';
-import {
-  MyJoinRoom,
-  ParticipatingRoom,
-  DayType,
-  TodayBugs
-} from '@/core/types';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { roomOptions } from '@/core/api/options';
+import { MyJoinRoom, ParticipatingRoom, DayType } from '@/core/types';
 import { DAY_TYPE } from '@/RoomSlide/constants/dayType';
 import NewRoomCard from './NewRoomCard';
 import { RoomCard } from '@/RoomList';

--- a/src/core/api/functions/bugAPI.ts
+++ b/src/core/api/functions/bugAPI.ts
@@ -1,10 +1,5 @@
 import { baseInstance } from '../instance';
-import { TodayBugs } from '@/core/types/TodayBugs';
 
-const bugAPI = {
-  getTodayBugs: async () => {
-    return await baseInstance.get<TodayBugs>('/bugs/today');
-  }
-};
+const bugAPI = {};
 
 export default bugAPI;

--- a/src/core/api/options/bug.ts
+++ b/src/core/api/options/bug.ts
@@ -1,12 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import bugAPI from '../functions/bugAPI';
 
-const bugOptions = {
-  today: () =>
-    queryOptions({
-      queryKey: ['bugs', 'today'] as const,
-      queryFn: () => bugAPI.getTodayBugs()
-    })
-};
+const bugOptions = {};
 
 export default bugOptions;

--- a/src/core/mocks/datas/todayBugs.ts
+++ b/src/core/mocks/datas/todayBugs.ts
@@ -1,6 +1,0 @@
-import { TodayBugs } from '@/core/types/TodayBugs';
-
-export const TODAY_BUGS: TodayBugs = {
-  morningBug: 9,
-  nightBug: 3
-};

--- a/src/core/mocks/handlers/bugs.ts
+++ b/src/core/mocks/handlers/bugs.ts
@@ -1,12 +1,11 @@
 import { http, HttpResponse, delay } from 'msw';
 import { baseURL } from '../baseURL';
-import { TODAY_BUGS } from '../datas/todayBugs';
 
 const bugsHandlers = [
   http.get(baseURL('/bugs/today'), async () => {
     await delay(1000);
-    return HttpResponse.json(TODAY_BUGS, { status: 200 });
-  })
+    return HttpResponse.json({}, { status: 200 });
+  }) // TODO: 나중에 bugs 다른 핸들러 머지되면 삭제하는 코드입니다. 충돌날까봐 남겨둡니다..
 ];
 
 export default bugsHandlers;

--- a/src/core/types/TodayBugs.ts
+++ b/src/core/types/TodayBugs.ts
@@ -1,4 +1,0 @@
-export interface TodayBugs {
-  morningBug: number;
-  nightBug: number;
-}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,4 +1,3 @@
-export type { TodayBugs } from './TodayBugs';
 export type { MyJoinRoom } from './MyJoinRoom';
 export type { DayType } from './Room';
 export type { ParticipatingRoom } from './MyJoinRoom';


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #201 

## ✅ 작업 사항
루틴 페이지에서 오늘얻은 아침벌레/밤벌레를 bug/today 에서 가져왔었는데, 이 API 가 없어졌더라구요..!
그로 인한 오류를 수정했습니닷
참여중인 방 조회 API 에서 계산하는 로직으로 수정했습니닷

## 👩‍💻 공유 포인트 및 논의 사항
