### PR TITLE
fix: 방 전체 조회 및 검색 페이지 오류 수정

### DIFF
--- a/src/RoomSlide/components/RoomSlide.tsx
+++ b/src/RoomSlide/components/RoomSlide.tsx
@@ -1,8 +1,10 @@
 import { Suspense } from 'react';
+import { ErrorBoundary } from '@suspensive/react';
 import { DAY_TYPE } from '../constants/dayType';
 import RoomData from './RoomData';
 import RoomDataFallback from './RoomDataFallback';
 import { Deffered } from '@/shared/Deffered';
+import { NetworkFallback } from '@/shared/ErrorBoundary';
 import { DayType } from '@/core/types/Room';
 
 interface RoomSlideProps {
@@ -19,15 +21,17 @@ const RoomSlide = ({ roomType }: RoomSlideProps) => {
           {START} ~ {END}시
         </div>
       </div>
-      <Suspense
-        fallback={
-          <Deffered>
-            <RoomDataFallback />
-          </Deffered>
-        }
-      >
-        <RoomData dayType={roomType} />
-      </Suspense>
+      <ErrorBoundary fallback={<NetworkFallback />}>
+        <Suspense
+          fallback={
+            <Deffered>
+              <RoomDataFallback />
+            </Deffered>
+          }
+        >
+          <RoomData dayType={roomType} />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/core/api/functions/roomAPI.ts
+++ b/src/core/api/functions/roomAPI.ts
@@ -57,6 +57,7 @@ const roomAPI = {
   },
 
   getRoomsAll: async (params?: RoomsRequestParams) => {
+    console.log(params);
     return await baseInstance.get<TotalRooms>('/rooms', { params });
   }
 };

--- a/src/core/api/queries/useSearchRooms.ts
+++ b/src/core/api/queries/useSearchRooms.ts
@@ -1,5 +1,5 @@
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { RoomSelectType } from '@/core/types';
+import { RoomSelectType, RoomsRequestParams } from '@/core/types';
 import roomAPI from '../functions/roomAPI';
 
 const useSearchRooms = ({
@@ -12,8 +12,16 @@ const useSearchRooms = ({
   return useSuspenseInfiniteQuery({
     queryKey: ['rooms', roomType, keyword],
 
-    queryFn: ({ pageParam }) =>
-      roomAPI.getRoomsAll({ roomType, roomId: pageParam, keyword }),
+    queryFn: ({ pageParam }) => {
+      const params: RoomsRequestParams = { roomType };
+      if (pageParam > 0) {
+        params.roomId = pageParam;
+      }
+      if (keyword) {
+        params.keyword = keyword;
+      }
+      return roomAPI.getRoomsAll(params);
+    },
 
     initialPageParam: 0,
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,9 +1,11 @@
 import { Suspense, useState } from 'react';
+import { ErrorBoundary } from '@suspensive/react';
 import { RoomSelectType } from '@/core/types';
 import { KeywordContext } from '@/RoomSearch';
 import { SearchBar, Selection, ResultList } from '@/RoomSearch';
 import { Deffered } from '@/shared/Deffered';
 import ResultListFallback from '@/RoomSearch/components/ResultListFallback';
+import { NetworkFallback } from '@/shared/ErrorBoundary';
 
 const SearchPage = () => {
   const [roomType, setRoomType] = useState<RoomSelectType>('all');
@@ -22,18 +24,20 @@ const SearchPage = () => {
           />
         </div>
         <div className="h-full overflow-y-auto px-5 py-4">
-          <Suspense
-            fallback={
-              <Deffered>
-                <ResultListFallback size={10} />
-              </Deffered>
-            }
-          >
-            <ResultList
-              roomType={roomType}
-              keyword={keyword}
-            />
-          </Suspense>
+          <ErrorBoundary fallback={<NetworkFallback />}>
+            <Suspense
+              fallback={
+                <Deffered>
+                  <ResultListFallback size={10} />
+                </Deffered>
+              }
+            >
+              <ResultList
+                roomType={roomType}
+                keyword={keyword}
+              />
+            </Suspense>
+          </ErrorBoundary>
         </div>
       </div>
     </KeywordContext.Provider>


### PR DESCRIPTION
## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #207

## ✅ 작업 사항
![image](https://github.com/team-moabam/moabam-FE/assets/62418379/d7e7d4db-e46b-40a6-ab6b-885de781cad2)
이러한 에러가 발생해서, 보내야 하는 param parameter 가 없을 때는 아예 빼버리게 하는 방식으로 수정했습니다!

하는 김에 검색 페이지 결과 에러바운더리로 감싸고,
루틴페이지도 에러바운더리로 감쌌습니다