### PR TITLE
feat: 검색 시 해당되는 루틴목록 아코디언 펼쳐지게 수정

### DIFF
--- a/src/RoomList/components/RoomAccordion.tsx
+++ b/src/RoomList/components/RoomAccordion.tsx
@@ -9,6 +9,19 @@ import { RoutineItem, RoutineList } from '@/shared/RoutineList';
 import { useKeyword } from '@/RoomSearch';
 import KeywordText from '@/RoomSearch/components/KeywordText';
 
+const isKeywordInRoutines = (
+  keyword: string,
+  routines: {
+    routineId: number;
+    content: string;
+  }[]
+) => {
+  if (keyword === '') return false;
+  return routines.some(({ content }) =>
+    content.toLowerCase().includes(keyword.toLowerCase())
+  );
+};
+
 interface RoomAccordionProps {
   room: Room;
 }
@@ -20,7 +33,10 @@ const RoomAccordion = ({ room }: RoomAccordionProps) => {
   const keyword = useKeyword();
 
   return (
-    <Accordion className="shrink-0">
+    <Accordion
+      className="shrink-0"
+      initialOpen={isKeywordInRoutines(keyword, routines)}
+    >
       <AccordionHeader
         buttonColored
         className={clsx(

--- a/src/shared/Accordion/components/Accordion.tsx
+++ b/src/shared/Accordion/components/Accordion.tsx
@@ -6,13 +6,18 @@ import useAccordionGroup from '../hooks/useAccordionGroup';
 
 interface AccordionProps {
   className?: string;
+  initialOpen?: boolean;
   children: React.ReactNode;
 }
-const Accordion = ({ children, className = '' }: AccordionProps) => {
+const Accordion = ({
+  children,
+  initialOpen = false,
+  className = ''
+}: AccordionProps) => {
   const [id] = useState(v4());
   const { containerStyle, setOpenedId, openedId, singleOpen } =
     useAccordionGroup();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(singleOpen ? false : initialOpen);
 
   const toggleOpen = () => {
     if (!singleOpen) setIsOpen((prev) => !prev);
@@ -22,6 +27,10 @@ const Accordion = ({ children, className = '' }: AccordionProps) => {
   useEffect(() => {
     if (singleOpen) setIsOpen(openedId === id);
   }, [id, openedId, singleOpen]);
+
+  useEffect(() => {
+    setIsOpen(initialOpen);
+  }, [initialOpen]);
 
   return (
     <div


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #219

## ✅ 작업 사항
검색 시, 키워드가 루틴 목록에 포함되면 아코디언이 열리는 기능을 구현했습니다
- Accordion 에 initialOpen prop 추가 (optional)
- 검색 페이지 수정


https://github.com/team-moabam/moabam-FE/assets/62418379/110ef960-0f32-440f-a062-88cbd94f6f40



