### PR TITLE
fix: navigate 도중 발생한 오류 수정

### DIFF
--- a/src/RoomNavigate/components/RoomNavigate.tsx
+++ b/src/RoomNavigate/components/RoomNavigate.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSuspenseQueries } from '@tanstack/react-query';
 import timeOption from '@/core/api/options/time';
 import { roomOptions } from '@/core/api/options';
@@ -19,13 +19,14 @@ const RoomNavigate = () => {
     ]
   });
 
-  const roomToMove = pickRoomToShow(data, today);
-  if (roomToMove) {
-    moveTo('roomDetail', { roomId: roomToMove.roomId }, { replace: true });
-    return <></>;
-  } else {
-    return <NoRoom />;
-  }
+  useEffect(() => {
+    const roomToMove = pickRoomToShow(data, today);
+    if (roomToMove) {
+      moveTo('roomDetail', { roomId: roomToMove.roomId }, { replace: true });
+    }
+  }, [data, moveTo, today]);
+
+  return <NoRoom />;
 };
 
 export default RoomNavigate;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #240

## ✅ 작업 사항

Room 리다이렉트 로직 중 발생한 오류를 수정했습니다
찾아보니, navigate 같은 경우 useEffect 안에서 해주지 않으면
페이지 컴포넌트 2개가 동시에 렌더링이 되어 오류가 나는거라 하네요 !

