### PR TITLE
refactor: 스토리 북 MDX, decorator 활용해서 정리

### DIFF
--- a/src/core/hooks/useTheme.mdx
+++ b/src/core/hooks/useTheme.mdx
@@ -1,0 +1,27 @@
+import { Canvas, Meta, Title, Controls } from '@storybook/blocks';
+import * as useThemeStories from './useTheme.stories';
+
+<Meta of={useThemeStories} />
+
+<Title />
+
+`light | black` 테마를 전역에서 관리하는 Context 훅입니다.
+
+<Controls />
+
+### Default
+
+기본적으로 main.tsx 에서 `ThemeProvider` 로 감싸져 있습니다.  
+또한 App 컴포넌트에서 최상위의 요소의 `className` 에 테마에 따른 다크모드 설정을 부여했습니다.  
+따라서 기본적으로는 다크 모드에 대한 스타일을 지정하기 위해 `useTheme()` 훅을 사용할 필요가 없습니다.  
+
+대신 className으로 `dark:` 를 부여해서 사용할 수 있습니다.
+
+<Canvas of={useThemeStories.Default} />
+
+### Portal
+
+다만 `createPortal()` 로 DOM 트리상의 다른 노드에 컴포넌트를 렌더링하는 경우에는  
+최상위 요소의 `className` 에 테마에 따른 다크모드 설정을 부여하는 과정이 필요합니다.
+
+이는 `useTheme()` 훅을 통해 얻은 `theme` 을 활용해서 수행할 수 있습니다.

--- a/src/core/hooks/useTheme.stories.tsx
+++ b/src/core/hooks/useTheme.stories.tsx
@@ -5,19 +5,24 @@ import { PORTALS } from '@/core/constants/portals';
 
 const meta = {
   title: 'Hooks/useTheme',
-  tags: ['autodocs'],
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'light, black 테마를 전역에서 관리하는 Context 훅입니다.<br/>' +
-          '`const context = useTheme();`<br/><br/>' +
-          '`context.theme`: 현재 테마의 상태 값입니다. (light | dark)<br/>' +
-          '`context.setTheme(theme)`: 테마를 변경합니다.<br/>' +
-          '`context.toggleTheme()`: 테마를 토글합니다.<br/>'
-      }
+  argTypes: {
+    theme: {
+      description: '현재 테마의 상태<br/>`(light | dark)`'
+    },
+    setTheme: {
+      description: '테마를 변경하는 함수<br/>`setTheme(theme: Theme)`'
+    },
+    toggleTheme: {
+      description: '테마를 토글하는 함수<br/>`toggleTheme()`'
     }
-  }
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    )
+  ]
 } satisfies Meta;
 
 export default meta;
@@ -25,42 +30,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '기본적으로 main.tsx 에서 `ThemeProvider` 로 감싸져 있습니다.<br/>' +
-          '또한 App 컴포넌트에서 최상위의 요소의 `className` 에 테마에 따른 다크모드 설정을 부여했습니다.<br/><br/>' +
-          '따라서 기본적으로는 다크 모드에 대한 스타일을 지정하기 위해 `useTheme()` 훅을 사용할 필요가 없습니다.<br/>' +
-          '대신 className으로 `dark:` 를 부여해서 사용할 수 있습니다.'
-      }
-    }
-  },
-  render: () => (
-    <ThemeProvider>
-      <DefaultPage />
-    </ThemeProvider>
-  )
+  render: () => <DefaultPage />
 };
 
 export const Portal: Story = {
-  args: {},
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '다만 `createPortal()` 로 DOM 트리상의 다른 노드에 컴포넌트를 렌더링하는 경우에는<br/>' +
-          '최상위 요소의 `className` 에 테마에 따른 다크모드 설정을 부여하는 과정이 필요합니다.<br/><br/>' +
-          '이는 `useTheme()` 훅을 통해 얻은 `theme` 을 활용해서 수행할 수 있습니다.'
-      }
-    }
-  },
-  render: () => (
-    <ThemeProvider>
-      <PortalPage />
-    </ThemeProvider>
-  )
+  render: () => <PortalPage />
 };
 
 const DefaultPage = () => {

--- a/src/shared/Funnel/Funnel.mdx
+++ b/src/shared/Funnel/Funnel.mdx
@@ -1,0 +1,42 @@
+import { Canvas, Meta } from '@storybook/blocks';
+
+import * as FunnelStories from './Funnel.stories';
+
+<Meta of={FunnelStories} />
+
+# Funnel
+
+순차적인 화면을 보여주는 데 도움을 주는 컴포넌트입니다.
+
+## **사용 방법**
+
+### 1. steps 정의
+
+```tsx
+const steps = ["방선택", "인증시간", "루틴정보", "비밀번호", "마무리"] as const;
+```
+
+### 2. useFunnel 훅 선언
+
+```tsx
+const funnel = useFunnel(steps, <최초로 보여줄 스텝>);
+```
+
+### 3. Funnel, Step 컴포넌트 사용
+
+```tsx
+<Funnel {...funnel}>
+  <Funnel.Step<typeof steps> name="마무리">마무리 페이지</Funnel.Step>
+  <Funnel.Step<typeof steps> name="방선택">방선택 페이지</Funnel.Step>
+  <Funnel.Step<typeof steps> name="인증시간">인증시간 페이지</Funnel.Step>
+  <Funnel.Step<typeof steps> name="루틴정보">루틴정보 페이지</Funnel.Step>
+  <Funnel.Step<typeof steps> name="비밀번호">비밀번호 페이지</Funnel.Step>
+  <div>Step 컴포넌트가 아닌 요소는 렌더링에서 무시돼요.</div>
+  <div>
+    children에 순서를 뒤죽박죽으로 등록해도 steps 배열에 들어가있는
+    순서로 스텝을 보여줘요.
+  </div>
+</Funnel>
+```
+
+<Canvas of={FunnelStories.Default} />

--- a/src/shared/Funnel/Funnel.stories.tsx
+++ b/src/shared/Funnel/Funnel.stories.tsx
@@ -2,15 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Funnel, useFunnel } from '.';
 
 const meta = {
-  title: 'Shared/Funnel',
-  tags: ['autodocs'],
-  parameters: {
-    docs: {
-      description: {
-        component: '순차적인 화면을 보여주는 데 도움을 주는 컴포넌트입니다.'
-      }
-    }
-  }
+  title: 'Shared/Funnel'
 } satisfies Meta<typeof Funnel>;
 
 export default meta;
@@ -18,26 +10,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '**퍼널 컴포넌트 사용 방법**<br/>' +
-          '**1. steps 정의** <br/>' +
-          '`const steps = ["방선택", "인증시간", "루틴정보", "비밀번호", "마무리"] as const;`<br/><br/>' +
-          '**2. useFunnel 훅 사용**<br/>' +
-          '`const funnel = useFunnel(steps, <최초로 보여줄 스텝>);`<br/><br/>' +
-          '**3. Funnel 컴포넌트 사용**<br/>' +
-          '`<Funnel {...funnel}>`<br/><br/>' +
-          '**4. Funnel.Step 컴포넌트 사용**<br/>' +
-          '`<Funnel.Step<typeof steps> name="방선택">방선택 페이지</Funnel.Step>`<br/>' +
-          '`<Funnel.Step<typeof steps> name="인증시간">인증시간 페이지</Funnel.Step>`<br/>' +
-          '`<Funnel.Step<typeof steps> name="루틴정보">루틴정보 페이지</Funnel.Step>`<br/>' +
-          '`<Funnel.Step<typeof steps> name="비밀번호">비밀번호 페이지</Funnel.Step>`<br/>' +
-          '`<Funnel.Step<typeof steps> name="마무리">마무리 페이지</Funnel.Step>`<br/>'
-      }
-    }
-  },
   render: () => <DefaultPage />
 };
 

--- a/src/shared/Icon/components/Icon.stories.tsx
+++ b/src/shared/Icon/components/Icon.stories.tsx
@@ -16,12 +16,14 @@ const meta = {
   component: Icon,
   argTypes: {
     icon: {
+      description: '적용할 아이콘 이름<br/>',
       control: {
         type: 'select',
         options: Object.keys(iconMap)
       }
     },
     size: {
+      description: '아이콘 크기<br/>',
       control: {
         type: 'select',
         options: [
@@ -47,25 +49,6 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
-
-const ProviderPage = () => {
-  return (
-    <IconContext.Provider value={{ className: 'text-green-500 text-[5rem]' }}>
-      <Icon
-        icon="HiHome"
-        size="md"
-      />
-      <Icon
-        icon="BiChevronDown"
-        size="md"
-      />
-      <Icon
-        icon="BiBugAlt"
-        size="md"
-      />
-    </IconContext.Provider>
-  );
-};
 
 export const Default: Story = {
   args: {
@@ -117,9 +100,22 @@ export const Provider: Story = {
       }
     }
   },
-  render: () => {
-    return <ProviderPage />;
-  }
+  render: (args) => (
+    <IconContext.Provider value={{ className: 'text-green-500 text-[5rem]' }}>
+      <Icon
+        icon="HiHome"
+        size="md"
+      />
+      <Icon
+        icon="BiChevronDown"
+        size="md"
+      />
+      <Icon
+        icon="BiBugAlt"
+        size="md"
+      />
+    </IconContext.Provider>
+  )
 };
 
 export const AllIcons: Story = {
@@ -133,19 +129,17 @@ export const AllIcons: Story = {
       }
     }
   },
-  render: () => {
-    return (
-      <div className="flex gap-2">
-        {Object.keys(iconMap).map((icon) => {
-          return (
-            <Icon
-              key={icon}
-              size="5xl"
-              icon={icon as keyof typeof iconMap}
-            />
-          );
-        })}
-      </div>
-    );
-  }
+  render: (args) => (
+    <div className="flex gap-2">
+      {Object.keys(iconMap).map((icon) => {
+        return (
+          <Icon
+            key={icon}
+            size="5xl"
+            icon={icon as keyof typeof iconMap}
+          />
+        );
+      })}
+    </div>
+  )
 };


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #261

## ✅ 작업 사항
간단하게 몇 가지의 스토리를 정리했어요.

- `useTheme`, `Funnel` 스토리의 설명을 MDX 파일로 분리
- Provider가 필요하던 스토리에 `decorator` 를 활용해서 주입

