### PR TITLE
fix: 방 상세페이지 기능들 수정

### DIFF
--- a/src/RoomDetail/components/RoomDetail.tsx
+++ b/src/RoomDetail/components/RoomDetail.tsx
@@ -9,9 +9,10 @@ import { DateRoomDetailContext } from './RoomDetailProvider';
 
 interface RoomDetailProps {
   roomId?: string;
+  checkedRoomJoin: boolean;
 }
 
-const RoomDetail = ({ roomId }: RoomDetailProps) => {
+const RoomDetail = ({ roomId, checkedRoomJoin }: RoomDetailProps) => {
   const { serverTime } = useContext(DateRoomDetailContext);
   const todayDate = `${(serverTime || new Date()).getFullYear()}-${
     (serverTime || new Date()).getMonth() + 1
@@ -26,7 +27,10 @@ const RoomDetail = ({ roomId }: RoomDetailProps) => {
   return (
     <>
       <RoomDetailMeta roomTitle={title} />
-      <RoomHeader title={title} />
+      <RoomHeader
+        title={title}
+        checkedRoomJoin={checkedRoomJoin}
+      />
       <RoomNotice content={announcement} />
       <RoomDetailContainer roomDetailData={roomDetailData} />
     </>

--- a/src/RoomDetail/components/RoomHeader.tsx
+++ b/src/RoomDetail/components/RoomHeader.tsx
@@ -6,9 +6,10 @@ import { Toast } from '@/shared/Toast';
 
 interface RoomHeaderProps {
   title: string;
+  checkedRoomJoin: boolean;
 }
 
-const RoomHeader = ({ title }: RoomHeaderProps) => {
+const RoomHeader = ({ title, checkedRoomJoin }: RoomHeaderProps) => {
   const { location } = useRouteData();
   const sharePath = `${import.meta.env.VITE_LOCALHOST}${location}`;
 
@@ -27,15 +28,17 @@ const RoomHeader = ({ title }: RoomHeaderProps) => {
       className="absolute z-[1] text-white"
     >
       <div className="flex">
-        <Link
-          to="setting"
-          className="mr-[1.06rem]"
-        >
-          <Icon
-            icon="MdEdit"
-            size="xl"
-          />
-        </Link>
+        {checkedRoomJoin && (
+          <Link
+            to="setting"
+            className="mr-[1.06rem]"
+          >
+            <Icon
+              icon="MdEdit"
+              size="xl"
+            />
+          </Link>
+        )}
         <button onClick={handleShareButtonClick}>
           <Icon
             icon="BiSolidShareAlt"

--- a/src/RoomDetail/components/RoomMemberRank.tsx
+++ b/src/RoomDetail/components/RoomMemberRank.tsx
@@ -31,9 +31,8 @@ const RoomMemberRank = ({
           {todayCertificateRank
             .filter((el) => el.rank <= 3)
             .map((el) => {
-              const { memberId, nickname, rank } = el;
-              const awakeImage = '/assets/skins/awakeOmokSkin0.png';
-              const sleepImage = '/assets/skins/sleepOmokSkin0.png';
+              const { memberId, nickname, rank, awakeImage, sleepImage } = el;
+
               return (
                 <Link
                   to={`/user/${memberId}`}

--- a/src/RoomDetail/components/RoomSemi.tsx
+++ b/src/RoomDetail/components/RoomSemi.tsx
@@ -11,9 +11,10 @@ import RoomPreview from './RoomPreview';
 interface RoomSemiProps {
   roomId?: string;
   serverTime: Date;
+  checkedRoomJoin: boolean;
 }
 
-const RoomSemi = ({ roomId, serverTime }: RoomSemiProps) => {
+const RoomSemi = ({ roomId, serverTime, checkedRoomJoin }: RoomSemiProps) => {
   const { data: roomSemiData } = useSuspenseQuery({
     ...roomOptions.semiDetail(roomId)
   });
@@ -33,14 +34,16 @@ const RoomSemi = ({ roomId, serverTime }: RoomSemiProps) => {
   return (
     <>
       <RoomDetailMeta roomTitle={title} />
-      <RoomHeader title={title} />
+      <RoomHeader
+        title={title}
+        checkedRoomJoin={checkedRoomJoin}
+      />
       <RoomNotice content={announcement} />
       <div className="h-[20.56rem] bg-[url('/level1.png')] bg-cover bg-no-repeat text-white">
         <div className="relative h-[20.56rem] overflow-hidden">
           {certifiedRanks.map((el) => {
-            const { memberId, nickname, rank } = el;
-            const awakeImage = '/assets/skins/awakeOmokSkin0.png';
-            const sleepImage = '/assets/skins/sleepOmokSkin0.png';
+            const { memberId, nickname, rank, awakeImage, sleepImage } = el;
+
             return (
               <span
                 key={memberId}

--- a/src/pages/RoomDetailPage.tsx
+++ b/src/pages/RoomDetailPage.tsx
@@ -34,12 +34,16 @@ const RoomDetailPage = () => {
           <Suspense fallback={<RoomDetailFallback />}>
             {checkedRoomJoin ? (
               <RoomDetailProvider serverTime={serverTime || new Date()}>
-                <RoomDetail roomId={roomId} />
+                <RoomDetail
+                  roomId={roomId}
+                  checkedRoomJoin={checkedRoomJoin}
+                />
               </RoomDetailProvider>
             ) : (
               <RoomSemi
                 roomId={roomId}
                 serverTime={serverTime || new Date()}
+                checkedRoomJoin={checkedRoomJoin}
               />
             )}
           </Suspense>


### PR DESCRIPTION
## 🧩 이슈 번호
- close #306 

## ✅ 작업 사항
 - 상세 페이지 헤더에서 방장만 방 수정 페이지 이동버튼 보이기
 - sleepImage, awakeImage 데이터 적용하기

## 👩‍💻 공유 포인트 및 논의 사항
