### PR TITLE
chore: 라우팅에 코드스플리팅 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { ErrorBoundary } from '@suspensive/react';
 import { useQuery } from '@tanstack/react-query';
@@ -9,10 +9,10 @@ import getTimeRange from './core/utils/getTimeRange';
 import { Navbar } from './shared/Navbar';
 import { UnknownFallback } from './shared/ErrorBoundary';
 import useCheckAuthRequired from './useCheckAuthRequired';
-import 'swiper/css';
-import 'swiper/css/bundle';
 import { AboutMoabam } from './AboutMoabam';
 import { CommonMeta } from './Meta';
+import 'swiper/css';
+import 'swiper/css/bundle';
 
 const App = () => {
   const { navBarRequired, path, pageName } = useRouteData();
@@ -42,7 +42,9 @@ const App = () => {
         <div className="app-container flex flex-col bg-light-main dark:bg-dark-main">
           <ErrorBoundary fallback={<UnknownFallback />}>
             <div className="h-full overflow-hidden bg-light-main text-black dark:bg-dark-main dark:text-white">
-              <Outlet />
+              <Suspense>
+                <Outlet />
+              </Suspense>
             </div>
 
             {navBarRequired && <Navbar currentPath={`/${path}`} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,12 @@ import { ErrorBoundary } from '@suspensive/react';
 import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { useRouteData, useTheme } from '@/core/hooks';
-import timeOption from './core/api/options/time';
-import getTimeRange from './core/utils/getTimeRange';
-import { Navbar } from './shared/Navbar';
-import { UnknownFallback } from './shared/ErrorBoundary';
+import timeOption from '@/core/api/options/time';
+import getTimeRange from '@/core/utils/getTimeRange';
+import { Navbar } from '@/shared/Navbar';
+import { UnknownFallback } from '@/shared/ErrorBoundary';
+import { LoadingSpinner } from '@/shared/LoadingSpinner';
+import { Deffered } from '@/shared/Deffered';
 import useCheckAuthRequired from './useCheckAuthRequired';
 import { AboutMoabam } from './AboutMoabam';
 import { CommonMeta } from './Meta';
@@ -42,7 +44,18 @@ const App = () => {
         <div className="app-container flex flex-col bg-light-main dark:bg-dark-main">
           <ErrorBoundary fallback={<UnknownFallback />}>
             <div className="h-full overflow-hidden bg-light-main text-black dark:bg-dark-main dark:text-white">
-              <Suspense>
+              <Suspense
+                fallback={
+                  <Deffered defferTime={500}>
+                    <div className="flex h-full items-center justify-center">
+                      <LoadingSpinner
+                        colorStyle="text-light-point dark:text-dark-point"
+                        size="7xl"
+                      />
+                    </div>
+                  </Deffered>
+                }
+              >
                 <Outlet />
               </Suspense>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ const App = () => {
             <div className="h-full overflow-hidden bg-light-main text-black dark:bg-dark-main dark:text-white">
               <Suspense
                 fallback={
-                  <Deffered defferTime={500}>
+                  <Deffered defferTime={2000}>
                     <div className="flex h-full items-center justify-center">
                       <LoadingSpinner
                         colorStyle="text-light-point dark:text-dark-point"

--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -8,7 +8,10 @@ const router = createBrowserRouter([
     element: <App />,
     children: Object.values(routes).map(({ path, element }) => ({
       path,
-      element
+      async lazy() {
+        const page = await element;
+        return { Component: page.default };
+      }
     }))
   }
 ]);

--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -8,10 +8,7 @@ const router = createBrowserRouter([
     element: <App />,
     children: Object.values(routes).map(({ path, element }) => ({
       path,
-      async lazy() {
-        const page = await element;
-        return { Component: page.default };
-      }
+      element
     }))
   }
 ]);

--- a/src/core/routes/routes.tsx
+++ b/src/core/routes/routes.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { RouteObject } from 'react-router-dom';
 
 interface Route {
   path: string;
   authRequired: boolean;
   navBarRequired: boolean;
-  element: Promise<{ default: React.ComponentType<RouteObject> }>;
+  element: React.ReactNode;
   pageName?: string;
 }
 
@@ -36,164 +35,191 @@ export type RouteNames =
 
 type Routes = Record<RouteNames, Route>;
 
+const Room = React.lazy(() => import('@/pages/Room'));
+const RoomDetailPage = React.lazy(() => import('@/pages/RoomDetailPage'));
+const RoomLogPage = React.lazy(() => import('@/pages/RoomLogPage'));
+const RoutinesPage = React.lazy(() => import('@/pages/RoutinesPage'));
+const SearchPage = React.lazy(() => import('@/pages/SearchPage'));
+const RoomNewPage = React.lazy(() => import('@/pages/RoomNewPage'));
+const RoomSettingPage = React.lazy(() => import('@/pages/RoomSettingPage'));
+const StartPage = React.lazy(() => import('@/pages/StartPage'));
+const EventPage = React.lazy(() => import('@/pages/EventPage'));
+const NotFoundPage = React.lazy(() => import('@/pages/NotFoundPage'));
+const JoinPage = React.lazy(() => import('@/pages/JoinPage'));
+const JoinKakaoPage = React.lazy(() => import('@/pages/JoinKakaoPage'));
+const UserPage = React.lazy(() => import('@/pages/UserPage'));
+const RankPage = React.lazy(() => import('@/pages/RankPage'));
+const CouponPage = React.lazy(() => import('@/pages/CouponPage'));
+const ParticipateLogPage = React.lazy(
+  () => import('@/pages/ParticipateLogPage')
+);
+const OrderLogPage = React.lazy(() => import('@/pages/OrderLogPage'));
+const StorePage = React.lazy(() => import('@/pages/StorePage'));
+const MyBirdPage = React.lazy(() => import('@/pages/MyBirdPage'));
+const GuidePage = React.lazy(() => import('@/pages/GuidePage'));
+const PurchaseSuccessPage = React.lazy(
+  () => import('@/pages/PurchaseSuccesPage')
+);
+const PurchaseFailPage = React.lazy(() => import('@/pages/PurchaseFailPage'));
+
 const routes: Routes = {
   start: {
     path: '',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/StartPage')
+    element: <StartPage />
   },
   guide: {
     path: 'guide',
     authRequired: false,
     navBarRequired: false,
-    element: import('@/pages/GuidePage'),
+    element: <GuidePage />,
     pageName: '환영해요'
   },
   join: {
     path: 'join',
     authRequired: false,
     navBarRequired: false,
-    element: import('@/pages/JoinPage'),
+    element: <JoinPage />,
     pageName: '시작하기'
   },
   joinKakao: {
     path: 'login/kakao/oauth',
     authRequired: false,
     navBarRequired: false,
-    element: import('@/pages/JoinKakaoPage'),
+    element: <JoinKakaoPage />,
     pageName: '시작하기'
   },
   routines: {
     path: 'routines',
     authRequired: true,
     navBarRequired: true,
-    element: import('@/pages/RoutinesPage'),
+    element: <RoutinesPage />,
     pageName: '나의 루틴'
   },
   search: {
     path: 'search',
     authRequired: true,
     navBarRequired: true,
-    element: import('@/pages/SearchPage'),
+    element: <SearchPage />,
     pageName: '루틴방 조회'
   },
   myPage: {
     path: 'user',
     authRequired: true,
     navBarRequired: true,
-    element: import('@/pages/UserPage'),
+    element: <UserPage />,
     pageName: '내 정보'
   },
   user: {
     path: 'user/:userId',
     authRequired: true,
     navBarRequired: true,
-    element: import('@/pages/UserPage'),
+    element: <UserPage />,
     pageName: '유저 정보'
   },
   myLog: {
     path: 'user/participate-log',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/ParticipateLogPage'),
+    element: <ParticipateLogPage />,
     pageName: '방 참여기록'
   },
   myOrderLog: {
     path: 'user/order-log',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/OrderLogPage'),
+    element: <OrderLogPage />,
     pageName: '구매 내역'
   },
   myCoupon: {
     path: 'user/coupon',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/CouponPage'),
+    element: <CouponPage />,
     pageName: '쿠폰함'
   },
   store: {
     path: 'store',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/StorePage'),
+    element: <StorePage />,
     pageName: '상점'
   },
   rank: {
     path: 'rank',
     authRequired: false,
     navBarRequired: false,
-    element: import('@/pages/RankPage'),
+    element: <RankPage />,
     pageName: '랭킹'
   },
   createRoom: {
     path: 'room/new',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/RoomNewPage'),
+    element: <RoomNewPage />,
     pageName: '방 생성'
   },
   room: {
     path: 'room',
     authRequired: true,
     navBarRequired: true,
-    element: import('@/pages/Room')
+    element: <Room />
   },
   roomDetail: {
     path: 'room/:roomId',
     authRequired: true,
     navBarRequired: true,
-    element: import('@/pages/RoomDetailPage'),
+    element: <RoomDetailPage />,
     pageName: '루틴방'
   },
   roomLog: {
     path: 'room/:roomId/log/:logId',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/RoomLogPage'),
+    element: <RoomLogPage />,
     pageName: '인증 기록'
   },
   roomSetting: {
     path: 'room/:roomId/setting',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/RoomSettingPage'),
+    element: <RoomSettingPage />,
     pageName: '방 설정'
   },
   mybird: {
     path: 'mybird',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/MyBirdPage'),
+    element: <MyBirdPage />,
     pageName: '새 커스텀'
   },
   event: {
     path: 'event',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/EventPage'),
+    element: <EventPage />,
     pageName: '이벤트/쿠폰'
   },
   purchaseSuccess: {
     path: 'purchase-success',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/PurchaseSuccesPage'),
+    element: <PurchaseSuccessPage />,
     pageName: '결제'
   },
   purchaseFail: {
     path: 'purchase-fail',
     authRequired: true,
     navBarRequired: false,
-    element: import('@/pages/PurchaseFailPage'),
+    element: <PurchaseFailPage />,
     pageName: '결제'
   },
   notFound: {
     path: '*',
     authRequired: false,
     navBarRequired: false,
-    element: import('@/pages/NotFoundPage')
+    element: <NotFoundPage />
   }
 } as const;
 

--- a/src/core/routes/routes.tsx
+++ b/src/core/routes/routes.tsx
@@ -1,32 +1,11 @@
 import React from 'react';
-import Room from '@/pages/Room';
-import RoomDetailPage from '@/pages/RoomDetailPage';
-import RoomLogPage from '@/pages/RoomLogPage';
-import RoutinesPage from '@/pages/RoutinesPage';
-import SearchPage from '@/pages/SearchPage';
-import RoomNewPage from '@/pages/RoomNewPage';
-import RoomSettingPage from '@/pages/RoomSettingPage';
-import StartPage from '@/pages/StartPage';
-import EventPage from '@/pages/EventPage';
-import NotFoundPage from '@/pages/NotFoundPage';
-import JoinPage from '@/pages/JoinPage';
-import JoinKakaoPage from '@/pages/JoinKakaoPage';
-import UserPage from '@/pages/UserPage';
-import RankPage from '@/pages/RankPage';
-import CouponPage from '@/pages/CouponPage';
-import ParticipateLogPage from '@/pages/ParticipateLogPage';
-import OrderLogPage from '@/pages/OrderLogPage';
-import StorePage from '@/pages/StorePage';
-import MyBirdPage from '@/pages/MyBirdPage';
-import GuidePage from '@/pages/GuidePage';
-import PurchaseSuccessPage from '@/pages/PurchaseSuccesPage';
-import PurchaseFailPage from '@/pages/PurchaseFailPage';
+import { RouteObject } from 'react-router-dom';
 
 interface Route {
   path: string;
   authRequired: boolean;
   navBarRequired: boolean;
-  element: React.ReactNode;
+  element: Promise<{ default: React.ComponentType<RouteObject> }>;
   pageName?: string;
 }
 
@@ -62,159 +41,159 @@ const routes: Routes = {
     path: '',
     authRequired: true,
     navBarRequired: false,
-    element: <StartPage />
+    element: import('@/pages/StartPage')
   },
   guide: {
     path: 'guide',
     authRequired: false,
     navBarRequired: false,
-    element: <GuidePage />,
+    element: import('@/pages/GuidePage'),
     pageName: '환영해요'
   },
   join: {
     path: 'join',
     authRequired: false,
     navBarRequired: false,
-    element: <JoinPage />,
+    element: import('@/pages/JoinPage'),
     pageName: '시작하기'
   },
   joinKakao: {
     path: 'login/kakao/oauth',
     authRequired: false,
     navBarRequired: false,
-    element: <JoinKakaoPage />,
+    element: import('@/pages/JoinKakaoPage'),
     pageName: '시작하기'
   },
   routines: {
     path: 'routines',
     authRequired: true,
     navBarRequired: true,
-    element: <RoutinesPage />,
+    element: import('@/pages/RoutinesPage'),
     pageName: '나의 루틴'
   },
   search: {
     path: 'search',
     authRequired: true,
     navBarRequired: true,
-    element: <SearchPage />,
+    element: import('@/pages/SearchPage'),
     pageName: '루틴방 조회'
   },
   myPage: {
     path: 'user',
     authRequired: true,
     navBarRequired: true,
-    element: <UserPage />,
+    element: import('@/pages/UserPage'),
     pageName: '내 정보'
   },
   user: {
     path: 'user/:userId',
     authRequired: true,
     navBarRequired: true,
-    element: <UserPage />,
+    element: import('@/pages/UserPage'),
     pageName: '유저 정보'
   },
   myLog: {
     path: 'user/participate-log',
     authRequired: true,
     navBarRequired: false,
-    element: <ParticipateLogPage />,
+    element: import('@/pages/ParticipateLogPage'),
     pageName: '방 참여기록'
   },
   myOrderLog: {
     path: 'user/order-log',
     authRequired: true,
     navBarRequired: false,
-    element: <OrderLogPage />,
+    element: import('@/pages/OrderLogPage'),
     pageName: '구매 내역'
   },
   myCoupon: {
     path: 'user/coupon',
     authRequired: true,
     navBarRequired: false,
-    element: <CouponPage />,
+    element: import('@/pages/CouponPage'),
     pageName: '쿠폰함'
   },
   store: {
     path: 'store',
     authRequired: true,
     navBarRequired: false,
-    element: <StorePage />,
+    element: import('@/pages/StorePage'),
     pageName: '상점'
   },
   rank: {
     path: 'rank',
     authRequired: false,
     navBarRequired: false,
-    element: <RankPage />,
+    element: import('@/pages/RankPage'),
     pageName: '랭킹'
   },
   createRoom: {
     path: 'room/new',
     authRequired: true,
     navBarRequired: false,
-    element: <RoomNewPage />,
+    element: import('@/pages/RoomNewPage'),
     pageName: '방 생성'
   },
   room: {
     path: 'room',
     authRequired: true,
     navBarRequired: true,
-    element: <Room />
+    element: import('@/pages/Room')
   },
   roomDetail: {
     path: 'room/:roomId',
     authRequired: true,
     navBarRequired: true,
-    element: <RoomDetailPage />,
+    element: import('@/pages/RoomDetailPage'),
     pageName: '루틴방'
   },
   roomLog: {
     path: 'room/:roomId/log/:logId',
     authRequired: true,
     navBarRequired: false,
-    element: <RoomLogPage />,
+    element: import('@/pages/RoomLogPage'),
     pageName: '인증 기록'
   },
   roomSetting: {
     path: 'room/:roomId/setting',
     authRequired: true,
     navBarRequired: false,
-    element: <RoomSettingPage />,
+    element: import('@/pages/RoomSettingPage'),
     pageName: '방 설정'
   },
   mybird: {
     path: 'mybird',
     authRequired: true,
     navBarRequired: false,
-    element: <MyBirdPage />,
+    element: import('@/pages/MyBirdPage'),
     pageName: '새 커스텀'
   },
   event: {
     path: 'event',
     authRequired: true,
     navBarRequired: false,
-    element: <EventPage />,
+    element: import('@/pages/EventPage'),
     pageName: '이벤트/쿠폰'
   },
   purchaseSuccess: {
     path: 'purchase-success',
     authRequired: true,
     navBarRequired: false,
-    element: <PurchaseSuccessPage />,
+    element: import('@/pages/PurchaseSuccesPage'),
     pageName: '결제'
   },
   purchaseFail: {
     path: 'purchase-fail',
     authRequired: true,
     navBarRequired: false,
-    element: <PurchaseFailPage />,
+    element: import('@/pages/PurchaseFailPage'),
     pageName: '결제'
   },
   notFound: {
     path: '*',
     authRequired: false,
     navBarRequired: false,
-    element: <NotFoundPage />
+    element: import('@/pages/NotFoundPage')
   }
 } as const;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ const setupMSW = async () => {
       const excludedUrls = [
         '/assets/',
         '/node_modules/',
+        '/src/',
         'chrome-extension://',
         'fonts.googleapis.com/css2',
         'cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2106@1.1'


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #318

## ✅ 작업 사항
- 페이지 라우팅별 코드 스플리팅 적용

## 👩‍💻 공유 포인트 및 논의 사항
### 빌드 결과 비교
Vite 기본 빌드 설정으로는 한 파일이 `500kb` 를 초과하게 되면 코드 스플리팅을 권유하는 경고 문구가 등장하는데요, 라우팅 경로별 코드 스플리팅을 적용하니 여러 파일로 나뉘어졌다는 점을 확인할 수 있었습니다.

#### 적용 전 빌드
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/18172e2c-95a4-4ed4-8ac2-dc27c12d9925)

#### 적용 후 빌드
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/6f1189cb-23ac-4809-a4a9-d723c1c515a1)

### 최초 페이지 로딩 비교

#### 적용 전 (preview)
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/239cc349-2fe2-4d12-adda-3c184da05509)

#### 적용 전 (dev)
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/a4e9397f-f69e-456d-b70e-adba85c54f2b)


#### 적용 후 (preview)
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/191e1174-b0a2-471d-9206-1b042c5d68e3)

#### 적용 후 (dev)
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/d8910383-2db4-45c3-89f9-01c3158ee471)


### 결론
크게 차이 없다고 느꼈습니다.

평소에 주로 로컬 개발서버를 사용하다보니 첫 페이지 로딩이 느리다고 생각했었는데 코드 스플리팅을 적용해도 생각보다 차이는 없는 것 같기도 하네요.. 실제 배포 환경에서는 더더욱 최초 로딩이 크게 느리다고 느껴지지도 않기도 하고..


### 장점
- 첫 페이지 로딩이 빨라짐.

### 단점
- 아직 가져오지 않은 라우팅 경로로 접근하면 사용자가 잠시 비어있는 화면을 보게 됨.
  - (로딩 처리를 더 섬세하게 하는 방법이 필요할까요?)

장점과 단점을 고려하여 코드 스플리팅을 적용해볼만 할지, 혹은 더 섬세한 처리를 해야 효과를 볼 수 있을지 있을지 의논해보면 좋을 것 같아요!


https://github.com/team-moabam/moabam-FE/assets/50488780/af25197d-d0ed-453f-b98c-f9a75c0b2ebc

