### PR TITLE
fix: 시작페이지 데이터 중복 요청 현상 수정

### DIFF
--- a/src/RoomSlide/components/RoomSlide.tsx
+++ b/src/RoomSlide/components/RoomSlide.tsx
@@ -14,13 +14,7 @@ const RoomSlide = ({ roomType }: RoomSlideProps) => {
   return (
     <div className="h-full overflow-auto px-8 pt-1">
       <ErrorBoundary fallback={<NetworkFallback />}>
-        <Suspense
-          fallback={
-            <Deffered>
-              <RoomDataFallback />
-            </Deffered>
-          }
-        >
+        <Suspense fallback={<RoomDataFallback />}>
           <RoomData dayType={roomType} />
         </Suspense>
       </ErrorBoundary>

--- a/src/RoomSlide/index.ts
+++ b/src/RoomSlide/index.ts
@@ -2,3 +2,4 @@ export { default as RoomSlide } from './components/RoomSlide';
 export { default as SlideController } from './components/SlideController';
 export { default as useDayTypes } from './hooks/useDayTypes';
 export { default as DayInfo } from './components/DayInfo';
+export { default as RoomDataFallback } from './components/RoomDataFallback';

--- a/src/StartSlide/components/FakeRoutinesPage.tsx
+++ b/src/StartSlide/components/FakeRoutinesPage.tsx
@@ -1,0 +1,25 @@
+import { DayType } from '@/core/types';
+import { DayInfo, RoomDataFallback } from '@/RoomSlide';
+
+interface FakeRoutinesPageProps {
+  dayType: DayType;
+}
+
+const FakeRoutinesPage = ({ dayType }: FakeRoutinesPageProps) => {
+  return (
+    <div className="flex h-full flex-col items-center overflow-auto">
+      <div className="mb-4 mt-8 flex w-full items-center justify-between px-10 pr-8">
+        <DayInfo dayType={dayType} />
+        <div className="h-10 w-14"></div>
+      </div>
+
+      <div className="h-full w-full">
+        <div className="h-full overflow-auto px-8 pt-1">
+          <RoomDataFallback />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FakeRoutinesPage;

--- a/src/StartSlide/index.ts
+++ b/src/StartSlide/index.ts
@@ -2,3 +2,4 @@ export { default as SwipeArrow } from './components/SwipeArrow';
 export { default as Background } from './components/Background';
 export { default as UserInfo } from './components/UserInfo';
 export { default as UserInfoFallback } from './components/UserInfoFallback';
+export { default as FakeRoutinesPage } from './components/FakeRoutinesPage';

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -10,9 +10,9 @@ import {
   UserInfoFallback,
   SwipeArrow,
   UserInfo,
-  Background
+  Background,
+  FakeRoutinesPage
 } from '@/StartSlide';
-import RoutinesPage from './RoutinesPage';
 
 const StartPage = () => {
   const { dayType } = useDayTypes();
@@ -27,7 +27,7 @@ const StartPage = () => {
         transition={{ duration: 0.5 }}
       >
         <div className="absolute h-full w-full">
-          <RoutinesPage />
+          <FakeRoutinesPage dayType={dayType} />
         </div>
         <Swiper
           className="h-full"


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #360

## ✅ 작업 사항
- 시작 슬라이드 밑에 RoutinesPage 를 겹쳐놔서 데이터 요청이 2번씩 되는 현상을 수정했습니다
- 실제 RoutinesPage 가 아닌.. FakeRoutinesPage (스켈레톤으로만 채워져 있는 정적 페이지) 를 작성해서 겹쳐놨습니다

따라서 시작 슬라이드에서는 members, serverTime 요청이 일어나고
시작 슬라이드를 다 올려서 페이지 전환이 이루어지면 my-join, coupon search 요청을 합니다



https://github.com/team-moabam/moabam-FE/assets/62418379/87c5e9a8-32ed-4c8c-a60c-0e271f996e57


