### PR TITLE
refactor: Web Push 관련 리팩토링

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -29,3 +29,20 @@ self.addEventListener('push', function (e) {
 
   self.registration.showNotification(title, options);
 });
+
+self.addEventListener('notificationclick', function (e) {
+  const title = e.notification?.title;
+  const roomId = Number(title);
+
+  let url = '/';
+
+  // 타이틀로 방 번호를 받으면 방 상세 페이지로 이동
+  if (!isNaN(roomId)) {
+    url = `/rooms/${roomId}`;
+  }
+
+  e.notification.close();
+
+  // eslint-disable-next-line no-undef
+  e.waitUntil(clients.openWindow(url));
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import queryClient from '@/core/api/queryClient';
 import { PWAInstallBannerProvider } from '@/PWAInstallBanner/hooks/usePWAInstallBanner';
 import './main.css';
 
+// MSW 서비스 워커 등록
 const setupMSW = async () => {
   if (import.meta.env.VITE_MSW !== 'true') {
     return;
@@ -39,6 +40,7 @@ const setupMSW = async () => {
   });
 };
 
+// FCM 서비스 워커 등록
 const setupSW = async () => {
   if (import.meta.env.VITE_MSW === 'true') {
     return;
@@ -55,6 +57,7 @@ const setupSW = async () => {
   });
 };
 
+// 알림 권한 허용 여부에 따라 FCM 토큰을 API 서버에 전송하는 이벤트 핸들러 등록
 const setupFCM = async () => {
   const debounce = new Debounce();
 

--- a/src/pages/JoinKakaoPage.tsx
+++ b/src/pages/JoinKakaoPage.tsx
@@ -25,8 +25,15 @@ const JoinKakaoPage = () => {
           moveTo(data.signUp ? 'guide' : 'start');
           localStorage.setItem(STORAGE_KEYS.MEMBER_ID, JSON.stringify(data.id));
 
-          const fcmToken = await getFCMToken();
-          notificationAPI.postFCMToken({ fcmToken });
+          if (Notification && Notification.permission === 'granted') {
+            // 알림 권한 허용된 상태면 FCM 토큰을 API 서버에 전송
+            const fcmToken = await getFCMToken();
+            notificationAPI.postFCMToken({ fcmToken });
+          } else {
+            // 알림 권한 허용되지 않은 상태면 알림 권한 요청
+            // (권한 승인시 자동으로 FCM 토큰을 API 서버에 전송)
+            Notification.requestPermission();
+          }
         }
       }
     );

--- a/src/pages/JoinKakaoPage.tsx
+++ b/src/pages/JoinKakaoPage.tsx
@@ -4,17 +4,13 @@ import { useMutation } from '@tanstack/react-query';
 import memberAPI from '@/core/api/functions/memberAPI';
 import { getFCMToken } from '@/core/utils/firebase';
 import notificationAPI from '@/core/api/functions/notificationAPI';
-import { useMoveRoute, useLocalStorage } from '@/core/hooks';
+import { useMoveRoute } from '@/core/hooks';
 import { STORAGE_KEYS } from '@/core/constants/storageKeys';
 import { LoadingSpinner } from '@/shared/LoadingSpinner';
 
 const JoinKakaoPage = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
-  const [memberId, setMemberId] = useLocalStorage<number | null>(
-    STORAGE_KEYS.MEMBER_ID,
-    null
-  );
   const moveTo = useMoveRoute();
 
   const { mutate, isPending, isError, error } = useMutation({
@@ -27,7 +23,7 @@ const JoinKakaoPage = () => {
       {
         onSuccess: async (data) => {
           moveTo(data.signUp ? 'guide' : 'start');
-          setMemberId(data.id);
+          localStorage.setItem(STORAGE_KEYS.MEMBER_ID, JSON.stringify(data.id));
 
           const fcmToken = await getFCMToken();
           notificationAPI.postFCMToken({ fcmToken });


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #368 

## ✅ 작업 사항
- [x] 카카오 로그인 redirect 페이지의 리렌더링을 방지하고자 `useLocalStorage` 훅 제거
- [x] 알림 끈 상태에서 로그인한 뒤에 알림을 허용하면 토큰 전송 API가 두 번 호출되는 문제 수정
- [x] Web Push 메시지 클릭 시 모아밤 켜지도록 작업
- [x] main.tsx 주석 추가 

## 👩‍💻 공유 포인트 및 논의 사항
![image](https://github.com/team-moabam/moabam-FE/assets/50488780/79e839db-8de8-49f6-bef8-436928047a0d)

타이틀에 숫자(roomId) 가 넘어오면 방 상세 페이지로 라우팅 하려고 하는데, 숫자만 오면 타이틀을 메시지에 그대로 보여주지 말고 바꿔서 보낼지 고민중이에요.