### PR TITLE
refactor: 헤더의 뒤로가기가 갇히는 문제 수정

### DIFF
--- a/src/pages/CouponPage.tsx
+++ b/src/pages/CouponPage.tsx
@@ -8,7 +8,7 @@ const CouponPage = () => {
   return (
     <div className="h-full overflow-auto">
       <Header
-        prev="myPage"
+        prev={-1}
         title="쿠폰함"
       />
       <Suspense

--- a/src/pages/CouponPage.tsx
+++ b/src/pages/CouponPage.tsx
@@ -8,7 +8,7 @@ const CouponPage = () => {
   return (
     <div className="h-full overflow-auto">
       <Header
-        prev={-1}
+        prev
         title="쿠폰함"
       />
       <Suspense

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -9,7 +9,7 @@ const EventPage = () => {
   return (
     <div className="flex h-full flex-col">
       <Header
-        prev={-1}
+        prev
         title="이벤트"
       />
       <ErrorBoundary fallback={<NetworkFallback />}>

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -1,19 +1,15 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from '@suspensive/react';
-import { useLocation } from 'react-router-dom';
 import { Header } from '@/shared/Header';
 import { Deffered } from '@/shared/Deffered';
 import { NetworkFallback } from '@/shared/ErrorBoundary';
 import { EventList, EventListFallback } from '@/Promotion';
 
 const EventPage = () => {
-  const { state } = useLocation();
-  const prevPage = state && state.from === 'routines' ? 'routines' : 'myPage';
-
   return (
     <div className="flex h-full flex-col">
       <Header
-        prev={prevPage}
+        prev={-1}
         title="이벤트"
       />
       <ErrorBoundary fallback={<NetworkFallback />}>

--- a/src/pages/MyBirdPage.tsx
+++ b/src/pages/MyBirdPage.tsx
@@ -15,7 +15,7 @@ const MyBirdPage = () => {
   return (
     <MyBirdProvider>
       <Header
-        prev="myPage"
+        prev={-1}
         className="absolute z-10 text-light-sub"
       >
         <Suspense>

--- a/src/pages/MyBirdPage.tsx
+++ b/src/pages/MyBirdPage.tsx
@@ -15,7 +15,7 @@ const MyBirdPage = () => {
   return (
     <MyBirdProvider>
       <Header
-        prev={-1}
+        prev
         className="absolute z-10 text-light-sub"
       >
         <Suspense>

--- a/src/pages/OrderLogPage.tsx
+++ b/src/pages/OrderLogPage.tsx
@@ -9,7 +9,7 @@ const OrderLogPage = () => {
     <>
       <div className="h-full overflow-auto">
         <Header
-          prev="myPage"
+          prev={-1}
           title="사용 내역"
           className="sticky top-0 bg-light-main dark:bg-dark-main"
         />

--- a/src/pages/OrderLogPage.tsx
+++ b/src/pages/OrderLogPage.tsx
@@ -9,7 +9,7 @@ const OrderLogPage = () => {
     <>
       <div className="h-full overflow-auto">
         <Header
-          prev={-1}
+          prev
           title="사용 내역"
           className="sticky top-0 bg-light-main dark:bg-dark-main"
         />

--- a/src/pages/ParticipateLogPage.tsx
+++ b/src/pages/ParticipateLogPage.tsx
@@ -8,7 +8,7 @@ const ParticipateLogPage = () => {
   return (
     <div className="h-full overflow-auto ">
       <Header
-        prev={-1}
+        prev
         title="방 참여 기록"
         className="sticky top-0 bg-light-main dark:bg-dark-main"
       />

--- a/src/pages/ParticipateLogPage.tsx
+++ b/src/pages/ParticipateLogPage.tsx
@@ -8,7 +8,7 @@ const ParticipateLogPage = () => {
   return (
     <div className="h-full overflow-auto ">
       <Header
-        prev="myPage"
+        prev={-1}
         title="방 참여 기록"
         className="sticky top-0 bg-light-main dark:bg-dark-main"
       />

--- a/src/pages/RankPage.tsx
+++ b/src/pages/RankPage.tsx
@@ -8,7 +8,7 @@ const RankPage = () => {
   return (
     <div className="flex h-full w-full max-w-md flex-col">
       <Header
-        prev={-1}
+        prev
         className="bg-light-sub dark:bg-dark-sub"
         title="랭킹"
       />

--- a/src/pages/RankPage.tsx
+++ b/src/pages/RankPage.tsx
@@ -8,7 +8,7 @@ const RankPage = () => {
   return (
     <div className="flex h-full w-full max-w-md flex-col">
       <Header
-        prev="myPage"
+        prev={-1}
         className="bg-light-sub dark:bg-dark-sub"
         title="랭킹"
       />

--- a/src/pages/RoomLogPage.tsx
+++ b/src/pages/RoomLogPage.tsx
@@ -13,7 +13,7 @@ const RoomLogPage = () => {
       <div className="bg-light-main dark:bg-dark-main">
         <Header
           className="sticky text-black"
-          prev={-1}
+          prev
           title={`${chooseDate.getFullYear()}년 ${
             chooseDate.getMonth() + 1
           }월 ${chooseDate.getDate()}일`}

--- a/src/pages/RoomLogPage.tsx
+++ b/src/pages/RoomLogPage.tsx
@@ -13,7 +13,7 @@ const RoomLogPage = () => {
       <div className="bg-light-main dark:bg-dark-main">
         <Header
           className="sticky text-black"
-          prev="roomDetail"
+          prev={-1}
           title={`${chooseDate.getFullYear()}년 ${
             chooseDate.getMonth() + 1
           }월 ${chooseDate.getDate()}일`}

--- a/src/pages/RoomNewPage.tsx
+++ b/src/pages/RoomNewPage.tsx
@@ -42,7 +42,7 @@ const RoomNewPage = () => {
       >
         <Header
           className="bg-light-main dark:bg-dark-main"
-          prev={-1}
+          prev
           title="방 만들기"
         />
         <main className="grow overflow-auto px-8 py-12">

--- a/src/pages/RoomNewPage.tsx
+++ b/src/pages/RoomNewPage.tsx
@@ -1,4 +1,3 @@
-import { useLocation } from 'react-router-dom';
 import { FormProvider } from 'react-hook-form';
 import { motion } from 'framer-motion';
 import { useFunnel, Funnel } from '@/shared/Funnel';
@@ -35,9 +34,6 @@ const RoomNewPage = () => {
   const funnel = useFunnel(steps);
   const { form, mutation, handleSubmit } = useRoomForm();
 
-  const { state } = useLocation();
-  const prevPage = state && state.from === 'room' ? 'room' : 'routines';
-
   return (
     <FormProvider {...form}>
       <form
@@ -46,7 +42,7 @@ const RoomNewPage = () => {
       >
         <Header
           className="bg-light-main dark:bg-dark-main"
-          prev={prevPage}
+          prev={-1}
           title="방 만들기"
         />
         <main className="grow overflow-auto px-8 py-12">

--- a/src/pages/RoomSettingPage.tsx
+++ b/src/pages/RoomSettingPage.tsx
@@ -25,7 +25,7 @@ const RoomSettingPage = () => {
             throw err;
           }}
         >
-          <Header prev={-1} />
+          <Header prev />
           <Tab
             align="center"
             itemStyle="mt-10 px-8"

--- a/src/pages/RoomSettingPage.tsx
+++ b/src/pages/RoomSettingPage.tsx
@@ -25,7 +25,7 @@ const RoomSettingPage = () => {
             throw err;
           }}
         >
-          <Header prev="roomDetail" />
+          <Header prev={-1} />
           <Tab
             align="center"
             itemStyle="mt-10 px-8"

--- a/src/pages/StorePage.tsx
+++ b/src/pages/StorePage.tsx
@@ -7,7 +7,7 @@ const StorePage = () => {
   return (
     <div className="relative h-full overflow-auto ">
       <Header
-        prev="myPage"
+        prev={-1}
         title="상점"
         className="sticky top-0 bg-light-main dark:bg-dark-main"
       />

--- a/src/pages/StorePage.tsx
+++ b/src/pages/StorePage.tsx
@@ -7,7 +7,7 @@ const StorePage = () => {
   return (
     <div className="relative h-full overflow-auto ">
       <Header
-        prev={-1}
+        prev
         title="상점"
         className="sticky top-0 bg-light-main dark:bg-dark-main"
       />

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -13,7 +13,7 @@ const UserPage = () => {
     <div className="relative h-full overflow-auto px-5 pb-5">
       <Header
         className="absolute left-0 top-0 z-10"
-        prev={-1}
+        prev
       />
       <Suspense
         fallback={

--- a/src/shared/Header/Header.stories.tsx
+++ b/src/shared/Header/Header.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
   args: {
     title: '페이지 제목',
     titleSize: 'xl',
-    prev: 'start'
+    prev: true
   },
   parameters: {
     docs: {
@@ -44,7 +44,7 @@ export const OnlyPrev: Story = {
   render: () => {
     return (
       <div className="h-40 w-full border bg-light-main">
-        <Header prev="start" />
+        <Header prev />
         <div className="m-10">page</div>
       </div>
     );
@@ -63,7 +63,7 @@ export const TitleSize: Story = {
     return (
       <div className="dark h-40 w-full border bg-dark-main">
         <Header
-          prev="start"
+          prev
           title={
             <div className="flex items-center gap-3">
               2023년 10월 31일 <Icon icon="BiBugAlt" />

--- a/src/shared/Header/components/Header.tsx
+++ b/src/shared/Header/components/Header.tsx
@@ -26,7 +26,16 @@ const Header = ({
 
   const goPrev = () => {
     if (!prev) return;
-    prev === -1 ? navigate(-1) : moveTo(prev);
+
+    if (prev === -1) {
+      if (history.state.idx === 0) {
+        return navigate('/');
+      } else {
+        return navigate(-1);
+      }
+    }
+
+    moveTo(prev);
   };
 
   return (

--- a/src/shared/Header/components/Header.tsx
+++ b/src/shared/Header/components/Header.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { PublicRouteNames, PrivateRouteNames } from '@/core/routes';
-import { useMoveRoute } from '@/core/hooks';
 import { Icon } from '@/shared/Icon';
 
 interface HeaderProps {
-  prev?: PublicRouteNames | PrivateRouteNames | -1;
+  prev?: boolean;
   title?: React.ReactNode;
   titleSize?: 'md' | 'xl';
   children?: React.ReactNode;
@@ -21,21 +19,16 @@ const Header = ({
   children,
   className = ''
 }: HeaderProps) => {
-  const moveTo = useMoveRoute();
   const navigate = useNavigate();
 
   const goPrev = () => {
     if (!prev) return;
 
-    if (prev === -1) {
-      if (history.state.idx === 0) {
-        return navigate('/');
-      } else {
-        return navigate(-1);
-      }
+    if (history.state.idx === 0) {
+      return navigate('/');
+    } else {
+      return navigate(-1);
     }
-
-    moveTo(prev);
   };
 
   return (
@@ -47,7 +40,7 @@ const Header = ({
     >
       {prev && (
         <div
-          onClick={() => goPrev()}
+          onClick={goPrev}
           className="flex h-12 w-12 cursor-pointer items-center justify-center"
         >
           <Icon


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #411 

## ✅ 작업 사항
기존의 뒤로가기가 새로운 히스토리를 쌓는 방식이다보니 뒤로가기가 두 번 연달아서 나오는 페이지에서는 같은 페이지에 갇히는 현상을 발견했어요. 이러한 문제점을 해결했습니다.

- 모든 헤더의 뒤로가기를 히스토리 스택을 빼는 방식으로 수정
- 헤더에서 뒤로 갈 페이지가 모아밤이 아니라면 `/` 페이지로 이동하는 로직 추가

## 👩‍💻 공유 포인트 및 논의 사항
### 문제 상황
https://github.com/team-moabam/moabam-FE/assets/50488780/7f6f1d84-24f4-45db-9431-ab798066fb2a


### 수정 결과
https://github.com/team-moabam/moabam-FE/assets/50488780/ac16819c-51cd-4c08-bd52-e88021e0e1fa

