### PR TITLE
feat: 시작슬라이드 다시 내려가는 기능 추가

### DIFF
--- a/src/StartSlide/components/FakeStartPage.tsx
+++ b/src/StartSlide/components/FakeStartPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { DayType } from '@/core/types';
+import { Background, SwipeArrow, UserInfoFallback } from '..';
+
+interface FakeStartPageProps {
+  dayType: DayType;
+}
+
+const FakeStartPage = ({ dayType }: FakeStartPageProps) => {
+  return (
+    <div className="h-full">
+      <Background type={dayType} />
+      <UserInfoFallback type={dayType} />
+      <div className="absolute inset-x-0 bottom-8 mx-auto w-fit">
+        <SwipeArrow />
+      </div>
+    </div>
+  );
+};
+
+export default FakeStartPage;

--- a/src/StartSlide/components/SlideDown.tsx
+++ b/src/StartSlide/components/SlideDown.tsx
@@ -22,10 +22,10 @@ const SlideDown = ({
     setIsDragging(true);
     setStartY(e.clientY);
   };
-  const handleTouchStart = (e: React.TouchEvent) => {
-    setIsDragging(true);
-    setStartY(e.changedTouches[0].pageY);
-  };
+  // const handleTouchStart = (e: React.TouchEvent) => {
+  //   setIsDragging(true);
+  //   setStartY(e.changedTouches[0].pageY);
+  // };
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (isDragging && startY !== null && slideRef.current) {
@@ -34,13 +34,13 @@ const SlideDown = ({
       setCurrentY((movedY / fullHeight) * 100);
     }
   };
-  const handleTouchMove = (e: React.TouchEvent) => {
-    if (isDragging && startY !== null && slideRef.current) {
-      const movedY = e.changedTouches[0].pageY - startY;
-      const fullHeight = slideRef.current.parentElement?.clientHeight || 0;
-      setCurrentY((movedY / fullHeight) * 100);
-    }
-  };
+  // const handleTouchMove = (e: React.TouchEvent) => {
+  //   if (isDragging && startY !== null && slideRef.current) {
+  //     const movedY = e.changedTouches[0].pageY - startY;
+  //     const fullHeight = slideRef.current.parentElement?.clientHeight || 0;
+  //     setCurrentY((movedY / fullHeight) * 100);
+  //   }
+  // };
 
   const handleSlideEnd = () => {
     if (isDragging) {
@@ -66,16 +66,17 @@ const SlideDown = ({
         transform: `translateY(${
           currentY > fullPercentage ? fullPercentage : currentY
         }%)`,
-        transition: isDragging ? 'none' : 'transform 0.3s'
+        transition: isDragging ? 'none' : 'transform 0.5s'
       }}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}
       onMouseUp={handleSlideEnd}
       onMouseLeave={handleSlideEnd}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleSlideEnd}
-      onTouchCancel={handleSlideEnd}
+      // onTouchStart={handleTouchStart}
+      // onTouchMove={handleTouchMove}
+      // onTouchEnd={handleSlideEnd}
+      // onTouchCancel={handleSlideEnd}
+      onDoubleClick={() => setCurrentY(fullPercentage)}
       className={className}
     >
       {children}

--- a/src/StartSlide/components/SlideDown.tsx
+++ b/src/StartSlide/components/SlideDown.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface SlideDownProps {
+  children: React.ReactNode;
+  className?: string;
+  fullPercentage?: number;
+  onSlideDown?: VoidFunction;
+}
+
+const SlideDown = ({
+  children,
+  className = '',
+  fullPercentage = 100,
+  onSlideDown
+}: SlideDownProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const [startY, setStartY] = useState<number | null>(null);
+  const [currentY, setCurrentY] = useState(0);
+  const slideRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    setIsDragging(true);
+    setStartY(e.clientY);
+  };
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (isDragging && startY !== null && slideRef.current) {
+      const movedY = e.clientY - startY;
+      const fullHeight = slideRef.current.parentElement?.clientHeight || 0;
+      setCurrentY((movedY / fullHeight) * 100);
+    }
+  };
+  const handleMouseUp = () => {
+    if (isDragging) {
+      setIsDragging(false);
+      setStartY(null);
+      setCurrentY((prev) => (prev > 40 ? fullPercentage : 0));
+    }
+  };
+
+  useEffect(() => {
+    if (currentY === fullPercentage) {
+      const timeoutId = setTimeout(() => {
+        onSlideDown && onSlideDown();
+      }, 200);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [currentY, fullPercentage, isDragging, onSlideDown]);
+
+  return (
+    <div
+      ref={slideRef}
+      style={{
+        transform: `translateY(${
+          currentY > fullPercentage ? fullPercentage : currentY
+        }%)`,
+        transition: isDragging ? 'none' : 'transform 0.3s'
+      }}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      className={className}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default SlideDown;

--- a/src/StartSlide/components/SlideDown.tsx
+++ b/src/StartSlide/components/SlideDown.tsx
@@ -22,6 +22,11 @@ const SlideDown = ({
     setIsDragging(true);
     setStartY(e.clientY);
   };
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsDragging(true);
+    setStartY(e.changedTouches[0].pageY);
+  };
+
   const handleMouseMove = (e: React.MouseEvent) => {
     if (isDragging && startY !== null && slideRef.current) {
       const movedY = e.clientY - startY;
@@ -29,14 +34,21 @@ const SlideDown = ({
       setCurrentY((movedY / fullHeight) * 100);
     }
   };
-  const handleMouseUp = () => {
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (isDragging && startY !== null && slideRef.current) {
+      const movedY = e.changedTouches[0].pageY - startY;
+      const fullHeight = slideRef.current.parentElement?.clientHeight || 0;
+      setCurrentY((movedY / fullHeight) * 100);
+    }
+  };
+
+  const handleSlideEnd = () => {
     if (isDragging) {
       setIsDragging(false);
       setStartY(null);
       setCurrentY((prev) => (prev > 40 ? fullPercentage : 0));
     }
   };
-
   useEffect(() => {
     if (currentY === fullPercentage) {
       const timeoutId = setTimeout(() => {
@@ -58,8 +70,12 @@ const SlideDown = ({
       }}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
+      onMouseUp={handleSlideEnd}
+      onMouseLeave={handleSlideEnd}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleSlideEnd}
+      onTouchCancel={handleSlideEnd}
       className={className}
     >
       {children}

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -28,7 +28,7 @@ const RoutinesPage = () => {
 
   return (
     <>
-      <div className="flex h-full flex-col items-center overflow-auto">
+      <div className="flex h-full select-none flex-col items-center overflow-auto">
         <div className="mb-4 mt-8 flex w-full items-center justify-between px-10 pr-8">
           <DayInfo dayType={dayType} />
           <SlideController
@@ -61,7 +61,7 @@ const RoutinesPage = () => {
         </Suspense>
       </div>
       <SlideDown
-        className="absolute top-[-100%] z-[100] h-full w-full bg-yellow-200"
+        className="absolute top-[-100%] z-[100] h-full w-full cursor-grabbing"
         fullPercentage={100}
         onSlideDown={() => moveTo('start', {}, { state: 'slide-down' })}
       >

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -1,11 +1,14 @@
-import { useState } from 'react';
-import { Suspense } from 'react';
-import { Swiper, SwiperSlide, useSwiper } from 'swiper/react';
+import { useState, useRef, Suspense } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
 import { Controller } from 'swiper/modules';
 import { SwiperClass } from 'swiper/react';
+import { useMoveRoute } from '@/core/hooks';
+import SlideDown from '@/StartSlide/components/SlideDown';
+import FakeStartPage from '@/StartSlide/components/FakeStartPage';
 import { EventBanner } from '@/Promotion';
 import { PWAInstallBanner } from '@/PWAInstallBanner';
 import { SlideController, useDayTypes, RoomSlide, DayInfo } from '@/RoomSlide';
+import { FakeRoutinesPage } from '@/StartSlide';
 
 const RoutinesPage = () => {
   const { DAY_TYPES, toggleDayType, dayType } = useDayTypes();
@@ -22,39 +25,50 @@ const RoutinesPage = () => {
     }
   };
 
+  const moveTo = useMoveRoute();
+
   return (
-    <div className="flex h-full flex-col items-center overflow-auto">
-      <div className="mb-4 mt-8 flex w-full items-center justify-between px-10 pr-8">
-        <DayInfo dayType={dayType} />
-        <SlideController
-          control={routineSwiper}
-          onSwiper={setControllSwiper}
-          onClick={handleClickController}
-        />
+    <>
+      <div className="flex h-full flex-col items-center overflow-auto">
+        <div className="mb-4 mt-8 flex w-full items-center justify-between px-10 pr-8">
+          <DayInfo dayType={dayType} />
+          <SlideController
+            control={routineSwiper}
+            onSwiper={setControllSwiper}
+            onClick={handleClickController}
+          />
+        </div>
+
+        <Swiper
+          className="h-full w-full"
+          modules={[Controller]}
+          controller={{ control: controllSwiper }}
+          onSwiper={setRoutineSwiper}
+          onSlideChange={toggleDayType}
+        >
+          {DAY_TYPES.map((dayType) => (
+            <SwiperSlide
+              className="h-full"
+              key={dayType}
+            >
+              <RoomSlide roomType={dayType} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+
+        <PWAInstallBanner />
+        <Suspense>
+          <EventBanner />
+        </Suspense>
       </div>
-
-      <Swiper
-        className="h-full w-full"
-        modules={[Controller]}
-        controller={{ control: controllSwiper }}
-        onSwiper={setRoutineSwiper}
-        onSlideChange={toggleDayType}
+      <SlideDown
+        className="absolute top-[-96%] z-[100] h-full w-full bg-yellow-200"
+        fullPercentage={96}
+        onSlideDown={() => moveTo('start')}
       >
-        {DAY_TYPES.map((dayType) => (
-          <SwiperSlide
-            className="h-full"
-            key={dayType}
-          >
-            <RoomSlide roomType={dayType} />
-          </SwiperSlide>
-        ))}
-      </Swiper>
-
-      <PWAInstallBanner />
-      <Suspense>
-        <EventBanner />
-      </Suspense>
-    </div>
+        <FakeStartPage dayType={DAY_TYPES[0]} />
+      </SlideDown>
+    </>
   );
 };
 

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, Suspense } from 'react';
+import { useState, Suspense } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Controller } from 'swiper/modules';
 import { SwiperClass } from 'swiper/react';
@@ -8,7 +8,6 @@ import FakeStartPage from '@/StartSlide/components/FakeStartPage';
 import { EventBanner } from '@/Promotion';
 import { PWAInstallBanner } from '@/PWAInstallBanner';
 import { SlideController, useDayTypes, RoomSlide, DayInfo } from '@/RoomSlide';
-import { FakeRoutinesPage } from '@/StartSlide';
 
 const RoutinesPage = () => {
   const { DAY_TYPES, toggleDayType, dayType } = useDayTypes();
@@ -64,7 +63,7 @@ const RoutinesPage = () => {
       <SlideDown
         className="absolute top-[-96%] z-[100] h-full w-full bg-yellow-200"
         fullPercentage={96}
-        onSlideDown={() => moveTo('start')}
+        onSlideDown={() => moveTo('start', {}, { state: 'slide-down' })}
       >
         <FakeStartPage dayType={DAY_TYPES[0]} />
       </SlideDown>

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -61,11 +61,12 @@ const RoutinesPage = () => {
         </Suspense>
       </div>
       <SlideDown
-        className="absolute top-[-96%] z-[100] h-full w-full bg-yellow-200"
-        fullPercentage={96}
+        className="absolute top-[-100%] z-[100] h-full w-full bg-yellow-200"
+        fullPercentage={100}
         onSlideDown={() => moveTo('start', {}, { state: 'slide-down' })}
       >
         <FakeStartPage dayType={DAY_TYPES[0]} />
+        <div className="h-10 bg-transparent"></div>
       </SlideDown>
     </>
   );

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -43,6 +43,7 @@ const StartPage = () => {
         direction="vertical"
         allowSlidePrev={false}
         onReachEnd={() => moveTo('routines')}
+        threshold={50}
       >
         <SwiperSlide className="shadow-lg">
           <Background type={dayType} />

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -1,5 +1,6 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { ErrorBoundary } from '@suspensive/react';
+import { useLocation } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { motion } from 'framer-motion';
 import { useMoveRoute } from '@/core/hooks';
@@ -17,40 +18,61 @@ import {
 const StartPage = () => {
   const { dayType } = useDayTypes();
   const moveTo = useMoveRoute();
+  const { state } = useLocation();
 
-  return (
-    <Deffered>
-      <motion.div
+  const [slided, setSlided] = useState(state === 'slide-down');
+
+  useEffect(() => {
+    if (state === 'slide-down') {
+      setSlided(true);
+    }
+  }, [state]);
+
+  const StartPageContent = () => (
+    <motion.div
+      className="h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: slided ? 0 : 0.5 }}
+    >
+      <div className="absolute h-full w-full">
+        <FakeRoutinesPage dayType={dayType} />
+      </div>
+      <Swiper
         className="h-full"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
+        direction="vertical"
+        allowSlidePrev={false}
+        onReachEnd={() => moveTo('routines')}
       >
-        <div className="absolute h-full w-full">
-          <FakeRoutinesPage dayType={dayType} />
-        </div>
-        <Swiper
-          className="h-full"
-          direction="vertical"
-          allowSlidePrev={false}
-          onReachEnd={() => moveTo('routines')}
-        >
-          <SwiperSlide className="shadow-lg">
-            <Background type={dayType} />
+        <SwiperSlide className="shadow-lg">
+          <Background type={dayType} />
 
-            <ErrorBoundary fallback={<NetworkFallback />}>
-              <Suspense fallback={<UserInfoFallback type={dayType} />}>
+          <ErrorBoundary fallback={<NetworkFallback />}>
+            <Suspense fallback={<UserInfoFallback type={dayType} />}>
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.5 }}
+              >
                 <UserInfo type={dayType} />
-              </Suspense>
-            </ErrorBoundary>
+              </motion.div>
+            </Suspense>
+          </ErrorBoundary>
 
-            <div className="absolute inset-x-0 bottom-8 mx-auto w-fit">
-              <SwipeArrow />
-            </div>
-          </SwiperSlide>
-          <SwiperSlide></SwiperSlide>
-        </Swiper>
-      </motion.div>
+          <div className="absolute inset-x-0 bottom-8 mx-auto w-fit">
+            <SwipeArrow />
+          </div>
+        </SwiperSlide>
+        <SwiperSlide></SwiperSlide>
+      </Swiper>
+    </motion.div>
+  );
+
+  return slided ? (
+    <StartPageContent />
+  ) : (
+    <Deffered>
+      <StartPageContent />
     </Deffered>
   );
 };

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -30,7 +30,7 @@ const StartPage = () => {
 
   const StartPageContent = () => (
     <motion.div
-      className="h-full"
+      className="h-full select-none"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: slided ? 0 : 0.5 }}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #371

## ✅ 작업 사항

시작 슬라이드 다시 내려오는 기능을 추가했습니다
이 기능을 위해서 UI 를 더 추가하는거는 지양하고 싶어서.. 최대한 숨겨진 기능마냥.. 상단의 박스에서 이벤트를 감지하게 했습니다

### PC : 드래그 가능, 더블 클릭 가능

https://github.com/team-moabam/moabam-FE/assets/62418379/51414c13-812c-4cb0-b24c-d63ec58314d6

### 모바일 : 더블탭만 가능

브라우저 자체 이벤트인 '당겨서 새로고침' 의 이벤트와 겹쳐서 제대로 동작하기 어려운 문제가 있었어요
이 외에도, 위-아래로 터치하는 이벤트에 할당된게 많은 것 같아서.. 모바일은 일단 더블탭 시 슬라이드가 내려오는 것으로 구현했어요

https://github.com/team-moabam/moabam-FE/assets/62418379/28e8f9ec-2408-4578-903b-4d4f5501468a



## 👩‍💻 공유 포인트 및 논의 사항
