### PR TITLE
feat: 닉네임 중복시 에러

### DIFF
--- a/src/UserProfile/components/UserProfile.tsx
+++ b/src/UserProfile/components/UserProfile.tsx
@@ -93,15 +93,24 @@ const UserProfile = ({
           message: '변경 성공',
           status: 'confirm'
         });
+        handleChangeNormalMode();
       },
-      onError: () => {
-        Toast.show({
-          message: '뭔가가 잘못되었습니다 ㄷㄷ',
-          status: 'danger'
-        });
+      onError: (e) => {
+        switch (e.request.status) {
+          case 409:
+            Toast.show({
+              message: '중복 닉네임 입니다.',
+              status: 'danger'
+            });
+            break;
+          default:
+            Toast.show({
+              message: '뭔가 잘 못 되었습니다.',
+              status: 'danger'
+            });
+        }
       }
     });
-    handleChangeNormalMode();
   };
 
   return (


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #481 

## ✅ 작업 사항
닉네임 중복시 에러를 냅니다.

1. 409 에러가 나면 닉네임이 중복되었습니다 라는 에러를 냅니다. 또한 수정 form 을 그대로 둡니다.
2. 수정이 성공한 경우에만 수정 form 을 닫습니다

## 👩‍💻 공유 포인트 및 논의 사항
409 에러가 아니라 다르게 처리해야 한다면 말씀해주세용