### PR TITLE
feat 유저에딧 트림처리

### DIFF
--- a/src/UserProfile/components/UserProfile.tsx
+++ b/src/UserProfile/components/UserProfile.tsx
@@ -79,7 +79,6 @@ const UserProfile = ({
 
     if (newNickname) modifyMemberRequest['nickname'] = newNickname;
     if (newIntro) modifyMemberRequest['intro'] = newIntro;
-    console.log(newNickname);
     if (newNickname.length < 2 || 10 < newNickname.length) {
       Toast.show({
         message: '닉네임은 2자에서 10자로!',
@@ -126,7 +125,6 @@ const UserProfile = ({
           <MdModeEdit />
         </div>
       )}
-
       {isEditMode ? (
         <form
           className="flex w-full flex-col items-center"
@@ -164,14 +162,15 @@ const UserProfile = ({
           </div>
           <div className="my-2 flex w-full max-w-[16rem] flex-col items-start gap-2">
             <input
-              placeholder={nickname}
+              // placeholder={nickname}
+              defaultValue={nickname}
               className={inputStyle}
               {...register('nickname')}
             />
 
             <input
-              placeholder={intro === '' ? '한 줄 소개' : intro}
               className={inputStyle}
+              defaultValue={intro === '' ? '한 줄 소개' : intro}
               {...register('intro')}
             />
             <span className="text-sm text-danger">

--- a/src/UserProfile/components/UserProfile.tsx
+++ b/src/UserProfile/components/UserProfile.tsx
@@ -7,8 +7,8 @@ import memberOptions from '@/core/api/options/member';
 import { Toast } from '@/shared/Toast';
 
 interface Inputs {
-  nickname?: string;
-  intro?: string;
+  nickname: string;
+  intro: string;
   profileImage?: File[];
 }
 
@@ -74,8 +74,20 @@ const UserProfile = ({
   }) => {
     const formData = new FormData();
     const modifyMemberRequest: ModifyMemberRequest = {};
-    if (nickname) modifyMemberRequest['nickname'] = nickname;
-    if (intro) modifyMemberRequest['intro'] = intro;
+    const newNickname = nickname.replaceAll(' ', '');
+    const newIntro = intro.trim();
+
+    if (newNickname) modifyMemberRequest['nickname'] = newNickname;
+    if (newIntro) modifyMemberRequest['intro'] = newIntro;
+    console.log(newNickname);
+    if (newNickname.length < 2 || 10 < newNickname.length) {
+      Toast.show({
+        message: '닉네임은 2자에서 10자로!',
+        status: 'danger'
+      });
+      return;
+    }
+
     formData.append(
       'modifyMemberRequest',
       new Blob([JSON.stringify(modifyMemberRequest)], {

--- a/src/core/mocks/handlers/members.ts
+++ b/src/core/mocks/handlers/members.ts
@@ -54,7 +54,10 @@ const membersHandlers = [
 
   http.post(baseURL('/members/modify'), async ({ request }) => {
     const data = await request.formData();
-    console.log(data);
+
+    for (const key of data.keys()) {
+      console.log(key, ':', data.get(key));
+    }
     await delay(200);
     return HttpResponse.json({}, { status: 200 });
   }),


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #489

## ✅ 작업 사항
이제 닉네임은 공백제외 2자에서 10자 사이만 가능합니다.
상태 메세지는 보내기전에 한 번 트림처리합니다.
플레이스 홀더가 아닌 디폴트 밸류로 변경했습니다.

## 👩‍💻 공유 포인트 및 논의 사항
