### PR TITLE
refactor: 방 생성, 관리 페이지 렌더링 최적화

### DIFF
--- a/src/domain/RoomForm/components/Routines.tsx
+++ b/src/domain/RoomForm/components/Routines.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { InnerTextInput } from '@/shared/Input';
 import { Icon } from '@/shared/Icon';
 import { FORM_LITERAL } from '../constants/literals';
@@ -8,12 +8,9 @@ import { errorStyle, iconButtonStyle } from '../constants/styles';
 const Routines = () => {
   const {
     register,
-    watch,
     control,
     formState: { errors }
   } = useFormContext<{ routines: Array<{ value: string }> }>();
-
-  const watchRoutines = watch('routines');
 
   const {
     append,
@@ -23,6 +20,8 @@ const Routines = () => {
     name: 'routines',
     control
   });
+
+  const watchRoutines = useWatch({ name: 'routines', control });
 
   const handleAppendRoutine = useCallback(() => {
     if (routines.length >= FORM_LITERAL.routines.max.value) {
@@ -52,7 +51,7 @@ const Routines = () => {
               wrapperStyle="w-full"
               textStyle="text-xs text-gray-400"
               text={
-                watchRoutines[idx].value.length.toString() +
+                watchRoutines[idx]?.value.length.toString() +
                 ' / ' +
                 FORM_LITERAL.routines.item.max.value
               }

--- a/src/domain/RoomForm/components/UserCount.tsx
+++ b/src/domain/RoomForm/components/UserCount.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { Icon } from '@/shared/Icon';
 import { iconButtonStyle, errorStyle } from '../constants/styles';
 import { FORM_LITERAL } from '../constants/literals';
@@ -7,11 +7,11 @@ import { FORM_LITERAL } from '../constants/literals';
 const UserCount = () => {
   const {
     setValue,
-    watch,
-    formState: { errors }
+    formState: { errors },
+    control
   } = useFormContext<{ userCount: number }>();
 
-  const watchUserCount = watch('userCount');
+  const watchUserCount = useWatch({ name: 'userCount', control });
 
   const handleSetUserCount = useCallback(
     (count: number) => {

--- a/src/domain/RoomNew/components/BirdCard.tsx
+++ b/src/domain/RoomNew/components/BirdCard.tsx
@@ -35,7 +35,7 @@ const BirdCard = ({
       )}
       onClick={handleSelect}
     >
-      <div className={clsx('w-24 rounded-full', BIRD[type].bg)}>
+      <div className={clsx('h-20 w-20 rounded-full', BIRD[type].bg)}>
         <img
           src={BIRD[type].image}
           className="p-4"

--- a/src/domain/RoomNew/components/BirdCardSection.tsx
+++ b/src/domain/RoomNew/components/BirdCardSection.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { roomOptions } from '@/core/api/options';
 import { QueryErrorBoundary, NetworkFallback } from '@/shared/ErrorBoundary';
 import {
@@ -13,9 +13,9 @@ import BirdCard from './BirdCard';
 import BirdCardFallback from './BirdCardFallback';
 
 const BirdCardSectionComponent = () => {
-  const { setValue, watch } = useFormContext<Inputs>();
+  const { setValue, control } = useFormContext<Inputs>();
 
-  const watchType = watch('roomType');
+  const watchType = useWatch({ name: 'roomType', control });
 
   const { data: roomCount } = useSuspenseQuery({
     ...roomOptions.myJoin(),

--- a/src/domain/RoomNew/components/StepTemplate.tsx
+++ b/src/domain/RoomNew/components/StepTemplate.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+interface StepTemplateProps {
+  children: React.ReactNode;
+}
+
+const StepTemplate = ({ children }: StepTemplateProps) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ ease: 'easeInOut', duration: 0.25 }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default StepTemplate;

--- a/src/domain/RoomNew/steps/BirdStep.tsx
+++ b/src/domain/RoomNew/steps/BirdStep.tsx
@@ -6,6 +6,7 @@ import {
 } from '../constants/styles';
 import { Inputs } from '../hooks/useRoomForm';
 import BirdCardSection from '../components/BirdCardSection';
+import StepTemplate from '../components/StepTemplate';
 
 const BirdStep = () => {
   const {
@@ -13,7 +14,7 @@ const BirdStep = () => {
   } = useFormContext<Inputs>();
 
   return (
-    <>
+    <StepTemplate>
       <h1 className={headingStyle}>
         <strong>어떤 새를</strong>
         <p>키우는 방일까요?</p>
@@ -30,7 +31,7 @@ const BirdStep = () => {
       {errors.roomType && (
         <p className={errorStyle}>{errors.roomType.message}</p>
       )}
-    </>
+    </StepTemplate>
   );
 };
 

--- a/src/domain/RoomNew/steps/PasswordStep.tsx
+++ b/src/domain/RoomNew/steps/PasswordStep.tsx
@@ -2,13 +2,14 @@ import clsx from 'clsx';
 import { FORM_LITERAL } from '@/domain/RoomForm/constants/literals';
 import { Password } from '@/domain/RoomForm';
 import { headingStyle, descriptionStyle } from '../constants/styles';
+import StepTemplate from '../components/StepTemplate';
 
 const PasswordStep = () => {
   const min = FORM_LITERAL.password.min.value;
   const max = FORM_LITERAL.password.max.value;
 
   return (
-    <>
+    <StepTemplate>
       <h1 className={headingStyle}>
         <strong>마지막 !</strong>
         <p>
@@ -21,7 +22,7 @@ const PasswordStep = () => {
       </p>
 
       <Password placeholder="비워두시면 공개방이 됩니다" />
-    </>
+    </StepTemplate>
   );
 };
 

--- a/src/domain/RoomNew/steps/RoutineStep.tsx
+++ b/src/domain/RoomNew/steps/RoutineStep.tsx
@@ -5,6 +5,7 @@ import { Routines, UserCount } from '@/domain/RoomForm';
 import { errorStyle } from '../constants/styles';
 import { Inputs } from '../hooks/useRoomForm';
 import { descriptionStyle } from '../constants/styles';
+import StepTemplate from '../components/StepTemplate';
 
 const RoutineStep = () => {
   const {
@@ -13,7 +14,7 @@ const RoutineStep = () => {
   } = useFormContext<Inputs>();
 
   return (
-    <>
+    <StepTemplate>
       <section className={sectionStyle}>
         <h2 className={headingStyle}>
           <b>방 이름</b>을 지어주세요.
@@ -39,7 +40,7 @@ const RoutineStep = () => {
         </h2>
         <UserCount />
       </section>
-    </>
+    </StepTemplate>
   );
 };
 

--- a/src/domain/RoomNew/steps/SummaryStep.tsx
+++ b/src/domain/RoomNew/steps/SummaryStep.tsx
@@ -5,6 +5,7 @@ import { formatHourString } from '@/domain/TimePicker/utils/hour';
 import { BIRD } from '@/domain/RoomForm/constants/literals';
 import { headingStyle, descriptionStyle } from '../constants/styles';
 import { Inputs } from '../hooks/useRoomForm';
+import StepTemplate from '../components/StepTemplate';
 
 interface Info {
   icon: keyof typeof iconMap;
@@ -14,7 +15,6 @@ interface Info {
 
 const SummaryStep = () => {
   const { getValues } = useFormContext<Inputs>();
-
   const routines = getValues('routines');
 
   const infos: Info[] = [
@@ -46,7 +46,7 @@ const SummaryStep = () => {
   ];
 
   return (
-    <>
+    <StepTemplate>
       <h1 className={headingStyle}>
         <strong>준비 끝 !</strong>
       </h1>
@@ -76,7 +76,7 @@ const SummaryStep = () => {
           </li>
         ))}
       </ul>
-    </>
+    </StepTemplate>
   );
 };
 

--- a/src/domain/RoomNew/steps/TimeStep.tsx
+++ b/src/domain/RoomNew/steps/TimeStep.tsx
@@ -8,6 +8,7 @@ import {
   errorStyle
 } from '../constants/styles';
 import { Inputs } from '../hooks/useRoomForm';
+import StepTemplate from '../components/StepTemplate';
 
 const TimeStep = () => {
   const {
@@ -18,7 +19,7 @@ const TimeStep = () => {
   const watchRoomType = useWatch({ name: 'roomType', control });
 
   return (
-    <>
+    <StepTemplate>
       <h1 className={headingStyle}>
         <strong>언제 </strong>
         인증할까요?
@@ -47,7 +48,7 @@ const TimeStep = () => {
       {errors.certifyTime && (
         <p className={errorStyle}>{errors.certifyTime.message}</p>
       )}
-    </>
+    </StepTemplate>
   );
 };
 

--- a/src/domain/RoomNew/steps/TimeStep.tsx
+++ b/src/domain/RoomNew/steps/TimeStep.tsx
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { formatHourString } from '@/domain/TimePicker/utils/hour';
 import { TIME_RANGE } from '@/domain/RoomForm/constants/literals';
 import { TimePicker } from '@/domain/TimePicker';
@@ -11,13 +11,11 @@ import { Inputs } from '../hooks/useRoomForm';
 
 const TimeStep = () => {
   const {
-    setValue,
-    watch,
+    control,
     formState: { errors }
   } = useFormContext<Inputs>();
 
-  const watchRoomType = watch('roomType');
-  const watchCertifyTime = watch('certifyTime');
+  const watchRoomType = useWatch({ name: 'roomType', control });
 
   return (
     <>
@@ -32,10 +30,16 @@ const TimeStep = () => {
 
       <section className="mt-10 flex w-full flex-col items-center gap-6">
         <div>{formatHourString(TIME_RANGE[watchRoomType][0])}</div>
-        <TimePicker
-          range={TIME_RANGE[watchRoomType]}
-          initialTime={watchCertifyTime}
-          onChangeTime={(time) => setValue('certifyTime', time)}
+        <Controller
+          name="certifyTime"
+          control={control}
+          render={({ field }) => (
+            <TimePicker
+              range={TIME_RANGE[watchRoomType]}
+              initialTime={field.value}
+              onChangeTime={field.onChange}
+            />
+          )}
         />
         <div>{formatHourString(TIME_RANGE[watchRoomType][1])}</div>
       </section>

--- a/src/domain/RoomSetting/tabs/RoomTab.tsx
+++ b/src/domain/RoomSetting/tabs/RoomTab.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { FormProvider } from 'react-hook-form';
+import { Controller, FormProvider } from 'react-hook-form';
 import ReactTextareaAutosize from 'react-textarea-autosize';
 import clsx from 'clsx';
 import { roomOptions } from '@/core/api/options';
@@ -44,11 +44,9 @@ const RoomTab = ({ roomId }: RoomTabProps) => {
   const {
     register,
     setValue,
-    watch,
+    control,
     formState: { errors }
   } = form;
-
-  const watchAnnouncement = watch('announcement');
 
   return (
     <FormProvider {...form}>
@@ -70,32 +68,38 @@ const RoomTab = ({ roomId }: RoomTabProps) => {
           )}
         </section>
 
-        <section className={sectionStyle}>
-          <label
-            className={clsx(labelStyle, 'flex justify-between')}
-            htmlFor="announcement"
-          >
-            <b>공지사항</b>
-            <p className="text-xs text-gray-400">
-              {watchAnnouncement.length} / {FORM_LITERAL.announcement.max.value}
-            </p>
-          </label>
-          <ReactTextareaAutosize
-            className={clsx(
-              'w-full resize-none p-3 text-sm',
-              'rounded-lg border border-gray-300 shadow-sm placeholder:text-gray-400',
-              'focus:border-light-point focus:outline-none focus:ring-1 focus:ring-light-point',
-              'dark:bg-dark-sub dark:focus:border-dark-point dark:focus:ring-dark-point'
-            )}
-            minRows={3}
-            maxLength={FORM_LITERAL.announcement.max.value}
-            id="announcement"
-            {...register('announcement')}
-          />
-          {errors.announcement && (
-            <p className={errorStyle}>{errors.announcement?.message}</p>
+        <Controller
+          name="announcement"
+          control={control}
+          render={({ field }) => (
+            <section className={sectionStyle}>
+              <label
+                className={clsx(labelStyle, 'flex justify-between')}
+                htmlFor="announcement"
+              >
+                <b>공지사항</b>
+                <p className="text-xs text-gray-400">
+                  {field.value.length} / {FORM_LITERAL.announcement.max.value}
+                </p>
+              </label>
+              <ReactTextareaAutosize
+                className={clsx(
+                  'w-full resize-none p-3 text-sm',
+                  'rounded-lg border border-gray-300 shadow-sm placeholder:text-gray-400',
+                  'focus:border-light-point focus:outline-none focus:ring-1 focus:ring-light-point',
+                  'dark:bg-dark-sub dark:focus:border-dark-point dark:focus:ring-dark-point'
+                )}
+                minRows={3}
+                maxLength={FORM_LITERAL.announcement.max.value}
+                id="announcement"
+                {...field}
+              />
+              {errors.announcement && (
+                <p className={errorStyle}>{errors.announcement?.message}</p>
+              )}
+            </section>
           )}
-        </section>
+        />
 
         <section className={sectionStyle}>
           <label

--- a/src/pages/RoomNewPage.tsx
+++ b/src/pages/RoomNewPage.tsx
@@ -1,5 +1,4 @@
 import { FormProvider } from 'react-hook-form';
-import { motion } from 'framer-motion';
 import { createFunnel } from '@/shared/Funnel';
 import { Header } from '@/shared/Header';
 import {
@@ -20,14 +19,6 @@ export const steps = [
   'SummaryStep'
 ] as const;
 
-const stepComponents: Record<(typeof steps)[number], JSX.Element> = {
-  BirdStep: <BirdStep />,
-  TimeStep: <TimeStep />,
-  RoutineStep: <RoutineStep />,
-  PasswordStep: <PasswordStep />,
-  SummaryStep: <SummaryStep />
-};
-
 const { Funnel, Step, useFunnel } = createFunnel(steps);
 
 const RoomNewPage = () => {
@@ -47,21 +38,21 @@ const RoomNewPage = () => {
         />
         <main className="grow overflow-auto px-8 py-12">
           <Funnel {...funnel}>
-            {steps.map((step) => (
-              <Step
-                key={step}
-                name={step}
-              >
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ ease: 'easeInOut', duration: 0.25 }}
-                >
-                  {stepComponents[step]}
-                </motion.div>
-              </Step>
-            ))}
+            <Step name="BirdStep">
+              <BirdStep />
+            </Step>
+            <Step name="TimeStep">
+              <TimeStep />
+            </Step>
+            <Step name="RoutineStep">
+              <RoutineStep />
+            </Step>
+            <Step name="PasswordStep">
+              <PasswordStep />
+            </Step>
+            <Step name="SummaryStep">
+              <SummaryStep />
+            </Step>
           </Funnel>
         </main>
         <Navbar

--- a/src/pages/RoomSettingPage.tsx
+++ b/src/pages/RoomSettingPage.tsx
@@ -13,37 +13,35 @@ const RoomSettingPage = () => {
   const roomId = params.roomId || '';
 
   return (
-    <>
-      <QueryErrorBoundary fallback={<NetworkFallback />}>
-        <ErrorBoundary
-          fallback={<NotFoundPage />}
-          onError={(err) => {
-            if (isAxiosError(err) && err.response?.status === 404) {
-              return;
-            }
+    <QueryErrorBoundary fallback={<NetworkFallback />}>
+      <ErrorBoundary
+        fallback={<NotFoundPage />}
+        onError={(err) => {
+          if (isAxiosError(err) && err.response?.status === 404) {
+            return;
+          }
 
-            throw err;
-          }}
+          throw err;
+        }}
+      >
+        <Header prev />
+        <Tab
+          align="center"
+          itemStyle="mt-10 px-8"
         >
-          <Header prev />
-          <Tab
-            align="center"
-            itemStyle="mt-10 px-8"
-          >
-            <TabItem title="방 관리">
-              <Suspense fallback={<LoadingFallback />}>
-                <RoomTab roomId={roomId} />
-              </Suspense>
-            </TabItem>
-            <TabItem title="멤버 관리">
-              <Suspense fallback={<LoadingFallback />}>
-                <MemberTab roomId={roomId} />
-              </Suspense>
-            </TabItem>
-          </Tab>
-        </ErrorBoundary>
-      </QueryErrorBoundary>
-    </>
+          <TabItem title="방 관리">
+            <Suspense fallback={<LoadingFallback />}>
+              <RoomTab roomId={roomId} />
+            </Suspense>
+          </TabItem>
+          <TabItem title="멤버 관리">
+            <Suspense fallback={<LoadingFallback />}>
+              <MemberTab roomId={roomId} />
+            </Suspense>
+          </TabItem>
+        </Tab>
+      </ErrorBoundary>
+    </QueryErrorBoundary>
   );
 };
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #507 

## ✅ 작업 사항
- 방 생성 페이지 렌더링 최적화
- 방 관리 페이지 렌더링 최적화
- 방 생성 페이지에서 StepTemplate 작성하는 방식으로 리팩토링


## 👩‍💻 공유 포인트 및 논의 사항
### 기존
![watch 리렌더링](https://github.com/team-moabam/moabam-FE/assets/50488780/074cb047-290c-4754-9be2-3da9b2c80953)

### 현재
![watch 최적화 결과](https://github.com/team-moabam/moabam-FE/assets/50488780/16baac3f-b639-4316-a3c8-0c9bb51f1b68)

기존에 watch 로 값의 변화를 감지하고 있다 보니, FormProvider 로 감싸진 전체 영역이 리렌더링되는 현상이 발생했었는데요,
여기에 useWatch를 사용하는 방식으로 수정하여 값을 구독하는 컴포넌트만 리렌더링되도록 했어요.

추가로, 페이지 내에 존재하는 컴포넌트를 분리하기에는 애매하지만 값이 변경되었을 때 전체가 리렌더링 되는 것이 아니라 특정 JSX만 리렌더링하고 싶은 경우에는 Controller를 사용했어요.
(ex. TimePicker)

Reference: https://github.com/orgs/react-hook-form/discussions/7558