### PR TITLE
refactor: fcm, msw 서비스 워커 통합

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,12 +14,19 @@ import { PWAInstallBannerProvider } from '@/domain/PWAInstallBanner/hooks/usePWA
 import { setupMockServiceWorker, setupFCMServiceWorker } from './setupWorker';
 import './main.css';
 
-// 조건에 따라서 원하는 서비스 워커를 등록
+// 앱에서 사용되는 FCM 서비스 워커, MSW 서비스 워커를 등록
 const setupSW = async () => {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const workerUrl = new URL('/firebase-messaging-sw.js', location.origin);
+  workerUrl.searchParams.set('msw', import.meta.env.VITE_MSW);
+
+  await setupFCMServiceWorker(workerUrl);
+
   if (import.meta.env.VITE_MSW === 'true') {
-    await setupMockServiceWorker();
-  } else {
-    await setupFCMServiceWorker();
+    await setupMockServiceWorker(workerUrl);
   }
 };
 

--- a/src/setupWorker.ts
+++ b/src/setupWorker.ts
@@ -1,8 +1,11 @@
 // MSW 서비스 워커를 등록하는 함수
-export const setupMockServiceWorker = async () => {
+export const setupMockServiceWorker = async (workerUrl: URL) => {
   const { worker } = await import('@/core/api/mocks/browser');
 
   return worker.start({
+    serviceWorker: {
+      url: workerUrl.href
+    },
     onUnhandledRequest(request, print) {
       const excludedUrls = [
         '/assets/',
@@ -22,17 +25,15 @@ export const setupMockServiceWorker = async () => {
 };
 
 // FCM 서비스 워커를 등록하는 함수
-export const setupFCMServiceWorker = async () => {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker
-      .register('/firebase-messaging-sw.js', {
-        scope: '/'
-      })
-      .then(() => {
-        navigator.serviceWorker.onmessage = (e) => {
-          const url = e.data;
-          location.href = url;
-        };
-      });
+export const setupFCMServiceWorker = async (workerUrl: URL) => {
+  return navigator.serviceWorker.register(workerUrl.href).then(() => {
+    navigator.serviceWorker.onmessage = (e) => {
+      const type = e.data?.type;
+      const url = e.data?.url;
+
+      if (type === 'notification-click') {
+        location.href = url;
+      }
+    };
   });
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       injectRegister: null,
-      strategies: 'injectManifest',
       filename: 'firebase-messaging-sw.js',
       manifest: {
         name: 'Moabam: 당신의 루틴을 지켜요!',


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #512

## ✅ 작업 사항
기존에는 fcm을 위한 service worker만 실행하거나, 혹은 msw를 위한 service worker만 실행할 수 있었는데요. 이를 동시에 실행할 수 있도록 작업했어요.

- MSW 서비스 워커를 FCM 서비스 워커와 통합하는 방식으로 수정 [(참고한 공식 문서 레퍼런스)](https://mswjs.io/docs/recipes/merging-service-workers)
- 서비스 워커 파일에서 lint disabled하지 않아도 되도록 [self property](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/self) 사용
- MSW 서비스 워커가 내부적으로 사용하는 `postMessage` API와 겹치지 않도록 기존 FCM 서비스 워커의 notificationclick 이벤트에서 `postMessage` 가 메인 스레드에 전달하는 데이터 형태 변경


## 👩‍💻 공유 포인트 및 논의 사항
Web Push를 위한 FCM 서비스 워커와 API 모킹을 위한 MSW 서비스 워커가 같이 실행되고 있음을 확인할 수 있어요.
실행 커맨드는 기존과 같아요.

```sh
npm run dev # web push를 수신하는 service worker만 실행
npm run dev:msw # web push를 수신 + api를 모킹하는 service worker를 병합해서 실행
```

![image](https://github.com/team-moabam/moabam-FE/assets/50488780/91f130dc-978a-4f1a-8ac6-31eb7dc60d43)
